### PR TITLE
Simplify Hey Culligan Man board styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,46 +1,61 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Glitch Art Video Lab</title>
-    <link rel="stylesheet" href="style.css" />
-  </head>
-  <body>
-    <header class="app-header">
-      <h1>Glitch Art Video Lab</h1>
-      <p class="tagline">Drag a video or use the picker to start experimenting.</p>
-    </header>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hey Culligan Man</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="menu" class="menu-overlay">
+    <div class="menu-card">
+      <h1>Hey Culligan Man</h1>
+      <p>Select a game mode to begin.</p>
+      <div class="menu-buttons">
+        <button data-players="1">1 Player</button>
+        <button data-players="2">2 Players</button>
+        <button data-players="3">3 Players</button>
+        <button data-players="4">4 Players</button>
+        <button data-mode="cpu">Play vs CPU</button>
+      </div>
+    </div>
+  </div>
 
-    <main class="app-main">
-      <section class="control-panel">
-        <div class="file-controls">
-          <label class="file-picker">
-            <input id="file-input" type="file" accept="video/mp4,video/webm,image/gif" />
-            <span>Load Video</span>
-          </label>
-          <button id="export-btn" class="primary" disabled>Export Video</button>
+  <main id="game" class="game hidden">
+    <div class="board-wrapper">
+      <div id="board-background"></div>
+      <div id="board"></div>
+      <div id="placement-layer"></div>
+    </div>
+    <aside class="side-panel">
+      <section class="announcer">
+        <h2>Announcer</h2>
+        <div id="announcer-log" class="announcer-log"></div>
+        <div id="dice-display" class="dice-display">
+          <span class="die">⚀</span>
+          <span class="die">⚀</span>
+          <span class="sum">= 2</span>
         </div>
-
-        <div id="effect-controls" class="effects"></div>
       </section>
-
-      <section class="preview-panel">
-        <div id="drop-zone" class="drop-zone">
-          <video id="source-video" crossorigin="anonymous" playsinline hidden></video>
-          <canvas id="output-canvas" width="640" height="360"></canvas>
-          <p class="drop-hint">Drop a video file here</p>
+      <section class="controls">
+        <h2>Controls</h2>
+        <div class="control-buttons">
+          <button id="roll-btn">Roll Dice</button>
+          <button id="confirm-placement" class="hidden">Confirm Placement</button>
+          <button id="skip-shift" class="hidden">Skip Shift</button>
         </div>
       </section>
-    </main>
+    </aside>
+  </main>
 
-    <footer class="app-footer">
-      <p>
-        Built with vanilla HTML, CSS, and JavaScript. All processing happens in your
-        browser — no uploads required.
-      </p>
-    </footer>
+  <div id="victory-modal" class="modal hidden">
+    <div class="modal-card">
+      <h2 id="victory-title">Winner!</h2>
+      <p id="victory-message"></p>
+      <button id="restart-btn">Return to Menu</button>
+    </div>
+  </div>
 
-    <script type="module" src="script.js"></script>
-  </body>
+  <script src="script.js"></script>
+</body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,490 +1,962 @@
-import { applyRGBShift } from "./effects/rgb_shift.js";
-import { applyFrameSmear } from "./effects/smear.js";
-import { applyBitPlane } from "./effects/bitplane.js";
-import { applyColorDrift } from "./effects/color_drift.js";
-
-const video = document.getElementById("source-video");
-const canvas = document.getElementById("output-canvas");
-const ctx = canvas.getContext("2d", { willReadFrequently: true });
-const dropZone = document.getElementById("drop-zone");
-const fileInput = document.getElementById("file-input");
-const exportButton = document.getElementById("export-btn");
-const effectControls = document.getElementById("effect-controls");
-const dropHint = dropZone.querySelector(".drop-hint");
-
-let currentObjectUrl = null;
-let animationHandle = null;
-let isRendering = false;
-let isExporting = false;
-
-const effectRuntimeState = new Map();
-const effectSettings = new Map();
-const effectUI = new Map();
-
-const EFFECTS = [
-  {
-    id: "rgbShift",
-    name: "RGB Channel Separation",
-    description: "Offset each color channel to create chromatic aberration.",
-    apply: applyRGBShift,
-    params: {
-      offset: {
-        type: "range",
-        label: "Offset (px)",
-        min: 0,
-        max: 40,
-        step: 1,
-        default: 6,
-      },
-    },
-  },
-  {
-    id: "smear",
-    name: "Frame Smear",
-    description: "Blend current frame with the previous frame for a trailing effect.",
-    apply: applyFrameSmear,
-    params: {
-      mix: {
-        type: "range",
-        label: "Smear strength",
-        min: 0,
-        max: 0.95,
-        step: 0.05,
-        default: 0.55,
-      },
-    },
-  },
-  {
-    id: "bitplane",
-    name: "Bit-plane Slicing",
-    description: "Drop or invert individual RGB bit planes for digital noise.",
-    apply: applyBitPlane,
-    params: {
-      dropEnabled: {
-        type: "toggle",
-        label: "Drop bit plane",
-        default: true,
-      },
-      drop: {
-        type: "range",
-        label: "Plane to drop",
-        min: 0,
-        max: 7,
-        step: 1,
-        default: 2,
-      },
-      invertEnabled: {
-        type: "toggle",
-        label: "Invert bit plane",
-        default: false,
-      },
-      invert: {
-        type: "range",
-        label: "Plane to invert",
-        min: 0,
-        max: 7,
-        step: 1,
-        default: 5,
-      },
-    },
-  },
-  {
-    id: "colorDrift",
-    name: "Color Drift",
-    description: "Shift hue and tweak saturation/lightness in HSL space.",
-    apply: applyColorDrift,
-    params: {
-      hue: {
-        type: "range",
-        label: "Hue shift",
-        min: -180,
-        max: 180,
-        step: 1,
-        default: 24,
-      },
-      saturation: {
-        type: "range",
-        label: "Saturation",
-        min: 0,
-        max: 2,
-        step: 0.05,
-        default: 1.05,
-      },
-      lightness: {
-        type: "range",
-        label: "Lightness",
-        min: 0,
-        max: 2,
-        step: 0.05,
-        default: 1,
-      },
-    },
-  },
+const TILE_DATA = [
+  { "tile_number": "1-1", "top": "S", "left": "", "middle": "N", "right": "N", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+  { "tile_number": "1-2", "top": "", "left": "", "middle": "N", "right": "N", "bottom": "N", "connections": { "middle": ["right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+  { "tile_number": "1-3", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+  { "tile_number": "1-4", "top": "", "left": "S", "middle": "S", "right": "S", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+  { "tile_number": "1-5", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+  { "tile_number": "1-6", "top": "", "left": "H", "middle": "H", "right": "", "bottom": "H", "connections": { "left": ["middle"], "middle": ["left", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "2-1", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "2-2", "top": "S", "left": "S", "middle": "N", "right": "H", "bottom": "H", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+  { "tile_number": "2-3", "top": "", "left": "", "middle": "N", "right": "N", "bottom": "N", "connections": { "middle": ["right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+  { "tile_number": "2-4", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+  { "tile_number": "2-5", "top": "", "left": "N", "middle": "N", "right": "", "bottom": "N", "connections": { "left": ["middle"], "middle": ["left", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "2-6", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "3-1", "top": "H", "left": "", "middle": "H", "right": "", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "3-2", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "3-3", "top": "S", "left": "S", "middle": "N", "right": "H", "bottom": "H", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+  { "tile_number": "3-4", "top": "", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "middle": ["bottom"], "bottom": ["middle"] } },
+  { "tile_number": "3-5", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "3-6", "top": "S", "left": "", "middle": "S", "right": "", "bottom": "S", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "4-1", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "4-2", "top": "H", "left": "", "middle": "H", "right": "", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "4-3", "top": "N", "left": "", "middle": "N", "right": "N", "bottom": "", "connections": { "top": ["middle"], "middle": ["top", "right"], "right": ["middle"] } },
+  { "tile_number": "4-4", "top": "H", "left": "H", "middle": "N", "right": "S", "bottom": "S", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+  { "tile_number": "4-5", "top": "H", "left": "", "middle": "H", "right": "", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "4-6", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "5-1", "top": "S", "left": "", "middle": "S", "right": "", "bottom": "S", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "5-2", "top": "N", "left": "", "middle": "N", "right": "N", "bottom": "", "connections": { "top": ["middle"], "middle": ["top", "right"], "right": ["middle"] } },
+  { "tile_number": "5-3", "top": "", "left": "S", "middle": "S", "right": "S", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+  { "tile_number": "5-4", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+  { "tile_number": "5-5", "top": "H", "left": "H", "middle": "N", "right": "S", "bottom": "S", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+  { "tile_number": "5-6", "top": "H", "left": "", "middle": "H", "right": "", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+  { "tile_number": "6-1", "top": "N", "left": "", "middle": "N", "right": "N", "bottom": "", "connections": { "top": ["middle"], "middle": ["top", "right"], "right": ["middle"] } },
+  { "tile_number": "6-2", "top": "", "left": "H", "middle": "H", "right": "H", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+  { "tile_number": "6-3", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+  { "tile_number": "6-4", "top": "", "left": "S", "middle": "S", "right": "S", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+  { "tile_number": "6-5", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+  { "tile_number": "6-6", "top": "H", "left": "H", "middle": "N", "right": "S", "bottom": "S", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } }
 ];
 
-function initEffectUI() {
-  EFFECTS.forEach((effect) => {
-    const defaults = Object.fromEntries(
-      Object.entries(effect.params).map(([key, config]) => [key, config.default ?? (config.type === "toggle" ? false : 0)])
-    );
-    effectSettings.set(effect.id, {
-      enabled: false,
-      params: defaults,
-    });
+const menuOverlay = document.getElementById("menu");
+const gameContainer = document.getElementById("game");
+const boardElement = document.getElementById("board");
+const placementLayer = document.getElementById("placement-layer");
+const announcerLog = document.getElementById("announcer-log");
+const diceDisplay = document.getElementById("dice-display");
+const rollBtn = document.getElementById("roll-btn");
+const confirmPlacementBtn = document.getElementById("confirm-placement");
+const skipShiftBtn = document.getElementById("skip-shift");
+const victoryModal = document.getElementById("victory-modal");
+const victoryTitle = document.getElementById("victory-title");
+const victoryMessage = document.getElementById("victory-message");
+const restartBtn = document.getElementById("restart-btn");
 
-    const group = document.createElement("div");
-    group.className = "effect-group";
+const PLAYER_COLORS = ["#f87171", "#38bdf8", "#facc15", "#a78bfa"];
+const EDGE_SPACE_RATIO = 0.2875;
+const SPACE_POSITIONS = {
+  top: { x: 0.5, y: EDGE_SPACE_RATIO },
+  right: { x: 1 - EDGE_SPACE_RATIO, y: 0.5 },
+  bottom: { x: 0.5, y: 1 - EDGE_SPACE_RATIO },
+  left: { x: EDGE_SPACE_RATIO, y: 0.5 },
+  middle: { x: 0.5, y: 0.5 }
+};
+const TYPE_CLASS_MAP = { S: "soft", N: "neutral", H: "hard" };
+const SIDES = ["top", "right", "bottom", "left"];
+const PHASES = {
+  AWAITING_ROLL: "AWAITING_ROLL",
+  AWAITING_MOVE: "AWAITING_MOVE",
+  AWAITING_SHIFT: "AWAITING_SHIFT",
+  BUMP_RELOCATE: "BUMP_RELOCATE",
+  GAME_OVER: "GAME_OVER"
+};
 
-    const header = document.createElement("div");
-    header.className = "effect-header";
+let boardState = new Map();
+let players = [];
+let playerTokens = new Map();
+let currentPlayerIndex = 0;
+let gamePhase = PHASES.AWAITING_ROLL;
+let finishRow = 2;
+let finishCol = 3;
+let diceResult = { die1: 1, die2: 1 };
+let pendingShift = null;
+let bumpContext = null;
+let announcerQueue = Promise.resolve();
+let cpuEnabled = false;
+let awaitingConfirm = false;
 
-    const title = document.createElement("h3");
-    title.textContent = effect.name;
-    header.appendChild(title);
-
-    const toggleLabel = document.createElement("label");
-    const toggle = document.createElement("input");
-    toggle.type = "checkbox";
-    toggle.addEventListener("change", () => setEffectEnabled(effect.id, toggle.checked));
-    toggleLabel.appendChild(toggle);
-    const toggleText = document.createElement("span");
-    toggleText.textContent = "Enable";
-    toggleLabel.appendChild(toggleText);
-    header.appendChild(toggleLabel);
-
-    group.appendChild(header);
-
-    const description = document.createElement("p");
-    description.className = "effect-description";
-    description.textContent = effect.description;
-    group.appendChild(description);
-
-    const sliderContainer = document.createElement("div");
-    sliderContainer.className = "effect-sliders";
-
-    const paramElements = new Map();
-
-    Object.entries(effect.params).forEach(([paramKey, config]) => {
-      if (config.type === "toggle") {
-        const row = document.createElement("label");
-        row.className = "slider-row";
-        const input = document.createElement("input");
-        input.type = "checkbox";
-        input.checked = Boolean(config.default);
-        input.addEventListener("change", () => {
-          updateEffectParam(effect.id, paramKey, input.checked);
-        });
-        const span = document.createElement("span");
-        span.textContent = config.label;
-        row.appendChild(input);
-        row.appendChild(span);
-        sliderContainer.appendChild(row);
-        paramElements.set(paramKey, { input, valueLabel: span, type: "toggle" });
-      } else {
-        const row = document.createElement("div");
-        row.className = "slider-row";
-        const label = document.createElement("span");
-        label.textContent = config.label;
-        const valueLabel = document.createElement("span");
-        valueLabel.textContent = config.default;
-        valueLabel.className = "slider-value";
-        const input = document.createElement("input");
-        input.type = "range";
-        input.min = config.min;
-        input.max = config.max;
-        input.step = config.step;
-        input.value = config.default;
-        input.addEventListener("input", () => {
-          const value = config.step % 1 === 0 ? parseInt(input.value, 10) : parseFloat(input.value);
-          valueLabel.textContent = value;
-          updateEffectParam(effect.id, paramKey, value);
-        });
-        row.appendChild(label);
-        row.appendChild(input);
-        row.appendChild(valueLabel);
-        sliderContainer.appendChild(row);
-        paramElements.set(paramKey, { input, valueLabel, type: "range" });
-      }
-    });
-
-    group.appendChild(sliderContainer);
-    effectControls.appendChild(group);
-
-    effectUI.set(effect.id, {
-      group,
-      toggle,
-      paramElements,
-    });
-
-    setEffectEnabled(effect.id, false);
+const menuButtons = document.querySelectorAll(".menu-buttons button");
+menuButtons.forEach((btn) => {
+  btn.addEventListener("click", () => {
+    if (btn.dataset.mode === "cpu") {
+      startGame(2, true);
+    } else {
+      startGame(Number(btn.dataset.players || 1), false);
+    }
   });
+});
+
+rollBtn.addEventListener("click", onRollDice);
+confirmPlacementBtn.addEventListener("click", confirmShiftPlacement);
+skipShiftBtn.addEventListener("click", () => {
+  if (isCurrentPlayerCPU()) return;
+  endShiftPhase(false);
+});
+restartBtn.addEventListener("click", () => {
+  victoryModal.classList.add("hidden");
+  menuOverlay.classList.remove("hidden");
+  gameContainer.classList.add("hidden");
+});
+
+displayDice(1, 1);
+
+function clearPlacementLayer() {
+  placementLayer.innerHTML = "";
+  placementLayer.style.pointerEvents = "none";
 }
 
-function setEffectEnabled(id, enabled) {
-  const settings = effectSettings.get(id);
-  if (!settings) return;
-  settings.enabled = enabled;
-
-  if (!enabled) {
-    effectRuntimeState.delete(id);
-  }
-
-  const ui = effectUI.get(id);
-  if (ui) {
-    ui.toggle.checked = enabled;
-    ui.group.classList.toggle("active", enabled);
-    ui.paramElements.forEach(({ input }) => {
-      input.disabled = !enabled;
-    });
+function startGame(playerCount, withCpu) {
+  cpuEnabled = withCpu;
+  boardState = new Map();
+  players = [];
+  playerTokens = new Map();
+  currentPlayerIndex = 0;
+  gamePhase = PHASES.AWAITING_ROLL;
+  finishRow = 2;
+  finishCol = 3;
+  diceResult = { die1: 1, die2: 1 };
+  pendingShift = null;
+  bumpContext = null;
+  awaitingConfirm = false;
+  clearPlacementLayer();
+  clearAnnouncer();
+  buildInitialBoard();
+  createPlayers(playerCount, withCpu);
+  renderBoard();
+  renderTokens();
+  highlightCurrentPlayer();
+  updateControls();
+  menuOverlay.classList.add("hidden");
+  gameContainer.classList.remove("hidden");
+  narrate(`Welcome to Hey Culligan Man! ${players.length} player game ready.`);
+  if (isCurrentPlayerCPU()) {
+    processCpuTurn();
   }
 }
 
-function updateEffectParam(id, paramKey, value) {
-  const settings = effectSettings.get(id);
-  if (!settings) return;
-  settings.params[paramKey] = value;
-  if (!settings.enabled) {
-    // Reset runtime state so changes are applied when enabled again.
-    effectRuntimeState.delete(id);
+function buildInitialBoard() {
+  for (let r = 0; r < 6; r++) {
+    for (let c = 0; c < 6; c++) {
+      const tileNumber = `${r + 1}-${c + 1}`;
+      const baseTile = TILE_DATA.find((t) => t.tile_number === tileNumber);
+      if (!baseTile) continue;
+      const tileState = createBoardTile(baseTile, 0, r, c);
+      boardState.set(`${r},${c}`, tileState);
+    }
   }
 }
 
-function getRuntimeState(id) {
-  if (!effectRuntimeState.has(id)) {
-    effectRuntimeState.set(id, {});
+function createPlayers(playerCount, withCpu) {
+  for (let i = 0; i < playerCount; i++) {
+    const isCpu = withCpu && i === 1;
+    const player = {
+      id: i + 1,
+      name: isCpu ? "Culligan CPU" : `Player ${i + 1}`,
+      color: PLAYER_COLORS[i % PLAYER_COLORS.length],
+      pos: null,
+      isCPU: isCpu,
+      missNextTurn: false
+    };
+    players.push(player);
+    const token = document.createElement("div");
+    token.className = "token";
+    token.style.background = player.color;
+    token.textContent = `${player.id}`;
+    token.dataset.player = player.id;
+    boardElement.appendChild(token);
+    playerTokens.set(player.id, token);
   }
-  return effectRuntimeState.get(id);
 }
 
-function handleFileSelection(file) {
-  if (!file) return;
-  if (!file.type.startsWith("video") && file.type !== "image/gif") {
-    console.warn("Unsupported file type", file.type);
-    return;
-  }
-
-  if (currentObjectUrl) {
-    URL.revokeObjectURL(currentObjectUrl);
-  }
-
-  currentObjectUrl = URL.createObjectURL(file);
-  video.src = currentObjectUrl;
-  video.loop = true;
-  video.muted = true;
-  video.playsInline = true;
-
-  video.addEventListener(
-    "loadedmetadata",
-    () => {
-      resizeCanvasToVideo();
-      dropZone.classList.add("loaded");
-      if (dropHint) {
-        dropHint.setAttribute("aria-hidden", "true");
-      }
-      startRendering();
-      video.play().catch((err) => console.warn("Autoplay prevented", err));
-      exportButton.disabled = false;
-    },
-    { once: true }
-  );
-
-  video.load();
-}
-
-function resizeCanvasToVideo() {
-  canvas.width = video.videoWidth;
-  canvas.height = video.videoHeight;
-}
-
-function startRendering() {
-  if (isRendering) return;
-  isRendering = true;
-  const loop = () => {
-    if (!isRendering) return;
-    renderFrame();
-    animationHandle = requestAnimationFrame(loop);
+function createBoardTile(baseTile, orientation, row, col) {
+  return {
+    base: structuredClone(baseTile),
+    orientation,
+    row,
+    col
   };
-  loop();
 }
 
-function stopRendering() {
-  isRendering = false;
-  if (animationHandle) {
-    cancelAnimationFrame(animationHandle);
-    animationHandle = null;
+function getTileState(boardTile) {
+  const { base, orientation } = boardTile;
+  const rotated = {
+    tile_number: base.tile_number,
+    row: boardTile.row,
+    col: boardTile.col,
+    orientation,
+    top: base.top,
+    right: base.right,
+    bottom: base.bottom,
+    left: base.left,
+    middle: base.middle,
+    connections: {}
+  };
+  for (let i = 0; i < SIDES.length; i++) {
+    const side = SIDES[i];
+    const baseSide = SIDES[(i - orientation + 4) % 4];
+    rotated[side] = base[baseSide];
   }
+  rotated.middle = base.middle;
+  const points = ["top", "right", "bottom", "left", "middle"];
+  points.forEach((point) => {
+    if (!base.connections[point]) return;
+    const newPoint = rotatePoint(point, orientation);
+    rotated.connections[newPoint] = base.connections[point].map((p) => rotatePoint(p, orientation));
+  });
+  return rotated;
 }
 
-function renderFrame() {
-  if (!video || video.readyState < 2) {
-    return;
+function rotatePoint(point, orientation) {
+  if (point === "middle") return "middle";
+  const idx = SIDES.indexOf(point);
+  if (idx === -1) return point;
+  return SIDES[(idx + orientation) % 4];
+}
+
+function renderBoard(extraCells = []) {
+  boardElement.innerHTML = "";
+  const { minRow, maxRow, minCol, maxCol } = getBoardBounds(extraCells);
+  const rows = maxRow - minRow + 1;
+  const cols = maxCol - minCol + 1;
+  const boardGrid = document.createElement("div");
+  boardGrid.className = "board-grid";
+  boardGrid.style.gridTemplateRows = `repeat(${rows}, var(--tile-size))`;
+  boardGrid.style.gridTemplateColumns = `repeat(${cols}, var(--tile-size))`;
+  const tileElements = new Map();
+
+  for (let r = minRow; r <= maxRow; r++) {
+    for (let c = minCol; c <= maxCol; c++) {
+      const key = `${r},${c}`;
+      const boardTile = boardState.get(key);
+      if (boardTile) {
+        const tileElement = buildTileElement(boardTile);
+        boardGrid.appendChild(tileElement);
+        tileElements.set(key, tileElement);
+      } else {
+        const empty = document.createElement("div");
+        empty.className = "empty-cell";
+        boardGrid.appendChild(empty);
+      }
+    }
   }
+  boardElement.appendChild(boardGrid);
+  boardGrid.dataset.minRow = minRow;
+  boardGrid.dataset.minCol = minCol;
+  boardElement.dataset.minRow = minRow;
+  boardElement.dataset.minCol = minCol;
+  boardElement.dataset.rows = rows;
+  boardElement.dataset.cols = cols;
+  boardElement._grid = boardGrid;
+  renderTokens(tileElements);
+}
 
-  ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-  let frame = ctx.getImageData(0, 0, canvas.width, canvas.height);
+function buildTileElement(boardTile) {
+  const tileState = getTileState(boardTile);
+  const tile = document.createElement("div");
+  tile.className = "board-tile";
+  tile.dataset.row = boardTile.row;
+  tile.dataset.col = boardTile.col;
+  tile.dataset.tile = boardTile.base.tile_number;
+  tile.dataset.orientation = boardTile.orientation;
+  const segments = document.createElement("div");
+  segments.className = "segments";
+  const spaces = [...SIDES, "middle"];
+  spaces.forEach((space) => {
+    const slot = document.createElement("div");
+    slot.className = `slot slot-${space}`;
+    slot.dataset.space = space;
+    const type = tileState[space];
+    if (type) {
+      const typeClass = TYPE_CLASS_MAP[type];
+      if (typeClass) {
+        slot.classList.add(typeClass);
+      }
+      slot.dataset.type = type;
+      slot.setAttribute("aria-label", `${space} ${type}`);
+    } else {
+      slot.classList.add("empty");
+    }
+    if (tileState.tile_number === "3-4" && space === "middle") {
+      slot.classList.add("finish");
+      slot.textContent = "Finish";
+    }
+    segments.appendChild(slot);
+  });
 
-  EFFECTS.forEach((effect) => {
-    const settings = effectSettings.get(effect.id);
-    if (!settings || !settings.enabled) {
-      effectRuntimeState.delete(effect.id);
+  const connectedToMiddle = (side) => {
+    return (
+      (tileState.connections.middle && tileState.connections.middle.includes(side)) ||
+      (tileState.connections[side] && tileState.connections[side].includes("middle"))
+    );
+  };
+
+  SIDES.forEach((side) => {
+    if (!connectedToMiddle(side)) return;
+    const pipe = document.createElement("div");
+    pipe.className = `pipe pipe-${side}`;
+    const type = tileState[side] || tileState.middle;
+    const typeClass = TYPE_CLASS_MAP[type];
+    if (typeClass) {
+      pipe.classList.add(typeClass);
+    }
+    segments.appendChild(pipe);
+  });
+
+  tile.appendChild(segments);
+  const label = document.createElement("div");
+  label.className = "tile-number";
+  label.textContent = tileState.tile_number;
+  tile.appendChild(label);
+
+  tile.addEventListener("click", () => {
+    onTileClicked(boardTile.row, boardTile.col);
+  });
+  return tile;
+}
+
+function renderTokens(tileElements = new Map()) {
+  players.forEach((player, idx) => {
+    const token = playerTokens.get(player.id);
+    if (!token) return;
+    if (!player.pos) {
+      token.style.display = "none";
       return;
     }
-    const state = getRuntimeState(effect.id);
-    const processed = effect.apply(frame, settings.params, state);
-    if (processed) {
-      frame = processed;
+    token.style.display = "flex";
+    const key = `${player.pos.row},${player.pos.col}`;
+    const tileElement = tileElements.get(key) || findTileElement(key);
+    if (tileElement) {
+      tileElement.appendChild(token);
+      const space = SPACE_POSITIONS[player.pos.space];
+      token.style.left = `${space.x * 100}%`;
+      token.style.top = `${space.y * 100}%`;
     }
+    token.classList.toggle("active", idx === currentPlayerIndex);
   });
-
-  ctx.putImageData(frame, 0, 0);
 }
 
-async function exportVideo() {
-  if (isExporting) {
+function findTileElement(key) {
+  const grid = boardElement._grid;
+  if (!grid) return null;
+  const [row, col] = key.split(",");
+  return grid.querySelector(`.board-tile[data-row="${row}"][data-col="${col}"]`);
+}
+
+function getBoardBounds(extraCells = []) {
+  let minRow = Infinity;
+  let maxRow = -Infinity;
+  let minCol = Infinity;
+  let maxCol = -Infinity;
+  boardState.forEach((tile) => {
+    minRow = Math.min(minRow, tile.row);
+    maxRow = Math.max(maxRow, tile.row);
+    minCol = Math.min(minCol, tile.col);
+    maxCol = Math.max(maxCol, tile.col);
+  });
+  extraCells.forEach((cell) => {
+    minRow = Math.min(minRow, cell.row);
+    maxRow = Math.max(maxRow, cell.row);
+    minCol = Math.min(minCol, cell.col);
+    maxCol = Math.max(maxCol, cell.col);
+  });
+  if (!isFinite(minRow)) {
+    minRow = 0;
+    maxRow = 0;
+    minCol = 0;
+    maxCol = 0;
+  }
+  return { minRow, maxRow, minCol, maxCol };
+}
+
+function onRollDice() {
+  if (gamePhase !== PHASES.AWAITING_ROLL) return;
+  const die1 = 1 + Math.floor(Math.random() * 6);
+  const die2 = 1 + Math.floor(Math.random() * 6);
+  diceResult = { die1, die2 };
+  displayDice(die1, die2);
+  narrate(`${currentPlayer().name} rolled ${die1} + ${die2} = ${die1 + die2}.`);
+  gamePhase = PHASES.AWAITING_MOVE;
+  updateControls();
+  handleMovementPhase();
+}
+
+function displayDice(d1, d2) {
+  const diceFaces = ["", "⚀", "⚁", "⚂", "⚃", "⚄", "⚅"];
+  const [span1, span2, sum] = diceDisplay.querySelectorAll("span");
+  span1.textContent = diceFaces[d1];
+  span2.textContent = diceFaces[d2];
+  sum.textContent = `= ${d1 + d2}`;
+}
+
+function handleMovementPhase() {
+  const player = currentPlayer();
+  const total = diceResult.die1 + diceResult.die2;
+  const startPos = player.pos;
+  const paths = findAllPaths(player, total);
+  if (paths.length === 0) {
+    narrate(`${player.name} cannot move ${total} spaces.`);
+    endMovementPhase(null);
     return;
   }
+  if (player.isCPU) {
+    chooseCpuMovement(paths);
+  } else {
+    enablePathSelection(paths);
+  }
+}
 
-  if (typeof canvas.captureStream !== "function") {
-    alert("MediaRecorder is not available. Consider adding ffmpeg.wasm in the lib directory as a fallback.");
+function findAllPaths(player, total) {
+  const targetSteps = player.pos ? total : Math.max(total - 1, 0);
+  if (targetSteps <= 0) {
+    return [];
+  }
+  const startNodes = player.pos
+    ? [player.pos]
+    : [{ row: 0, col: 0, space: "middle" }];
+  const paths = [];
+  startNodes.forEach((start) => {
+    depthSearch(start, targetSteps, [start], new Set([posKey(start)]), paths);
+  });
+  return paths;
+}
+
+function depthSearch(node, stepsRemaining, path, visited, outPaths) {
+  if (stepsRemaining === 0) {
+    outPaths.push([...path]);
     return;
   }
+  const neighbors = getNeighbors(node);
+  neighbors.forEach((neighbor) => {
+    const key = posKey(neighbor);
+    if (visited.has(key)) return;
+    const newVisited = new Set(visited);
+    newVisited.add(key);
+    path.push(neighbor);
+    depthSearch(neighbor, stepsRemaining - 1, path, newVisited, outPaths);
+    path.pop();
+  });
+}
 
-  isExporting = true;
-  exportButton.disabled = true;
+function getNeighbors(position) {
+  const tileKey = `${position.row},${position.col}`;
+  const boardTile = boardState.get(tileKey);
+  if (!boardTile) return [];
+  const tileState = getTileState(boardTile);
+  const connectionTargets = tileState.connections[position.space] || [];
+  const results = [];
+  connectionTargets.forEach((target) => {
+    if (target === "middle") {
+      results.push({ row: position.row, col: position.col, space: target });
+    } else if (SIDES.includes(target)) {
+      const neighbor = getNeighborTile(position.row, position.col, target);
+      if (!neighbor) return;
+      const neighborState = getTileState(neighbor);
+      const opposite = SIDES[(SIDES.indexOf(target) + 2) % 4];
+      if (!neighborState[opposite]) return;
+      const neighborConnections = neighborState.connections[opposite] || [];
+      if (!neighborConnections.includes("middle")) {
+        results.push({ row: neighbor.row, col: neighbor.col, space: opposite });
+      } else {
+        results.push({ row: neighbor.row, col: neighbor.col, space: "middle" });
+      }
+    }
+  });
+  return results;
+}
 
-  const stream = canvas.captureStream(30);
-  const mimeCandidates = [
-    "video/webm;codecs=vp9",
-    "video/webm;codecs=vp8",
-    "video/webm",
+function getNeighborTile(row, col, side) {
+  const offsets = { top: [-1, 0], right: [0, 1], bottom: [1, 0], left: [0, -1] };
+  const delta = offsets[side];
+  const key = `${row + delta[0]},${col + delta[1]}`;
+  return boardState.get(key);
+}
+
+function posKey(pos) {
+  return `${pos.row},${pos.col},${pos.space}`;
+}
+
+function enablePathSelection(paths) {
+  if (!boardElement._grid || !paths.length) return;
+  const overlays = document.createElement("div");
+  overlays.className = "overlay-grid";
+  overlays.style.gridTemplateRows = boardElement._grid.style.gridTemplateRows;
+  overlays.style.gridTemplateColumns = boardElement._grid.style.gridTemplateColumns;
+  clearPlacementLayer();
+  placementLayer.appendChild(overlays);
+  placementLayer.style.pointerEvents = "auto";
+  const endPositions = new Map();
+  paths.forEach((path) => {
+    const end = path[path.length - 1];
+    const key = `${end.row},${end.col},${end.space}`;
+    if (!endPositions.has(key)) {
+      endPositions.set(key, []);
+    }
+    endPositions.get(key).push(path);
+  });
+  const minRow = Number(boardElement.dataset.minRow || 0);
+  const minCol = Number(boardElement.dataset.minCol || 0);
+  endPositions.forEach((pathOptions, key) => {
+    const [rowStr, colStr, space] = key.split(",");
+    const row = Number(rowStr);
+    const col = Number(colStr);
+    const boardTile = boardState.get(`${row},${col}`);
+    const tileState = boardTile ? getTileState(boardTile) : null;
+    const typeClass = tileState ? TYPE_CLASS_MAP[tileState[space]] : null;
+    const target = document.createElement("button");
+    target.type = "button";
+    target.className = `bump-target target-${space}`;
+    target.style.gridRowStart = row - minRow + 1;
+    target.style.gridColumnStart = col - minCol + 1;
+    target.dataset.space = space;
+    target.setAttribute("aria-label", `Move to ${space}`);
+    if (typeClass) {
+      target.classList.add(typeClass);
+    }
+    target.addEventListener("click", () => {
+      clearPlacementLayer();
+      executeMovement(pathOptions[0]);
+    });
+    overlays.appendChild(target);
+  });
+}
+
+function executeMovement(path) {
+  const player = currentPlayer();
+  const start = player.pos;
+  const end = path[path.length - 1];
+  player.pos = { ...end };
+  renderBoard();
+  renderTokens();
+  narrate(`${player.name} moved to (${end.row}, ${end.col}) ${end.space}.`);
+  clearPlacementLayer();
+  handleLandingEffects(player, end);
+}
+
+function handleLandingEffects(player, endPosition) {
+  const tileState = getTileState(boardState.get(`${endPosition.row},${endPosition.col}`));
+  const spaceType = tileState[endPosition.space];
+  const occupant = getPlayerAt(endPosition, player.id);
+  const finishReached = endPosition.row === finishRow && endPosition.col === finishCol && endPosition.space === "middle";
+  if (finishReached) {
+    endGame(player);
+    return;
+  }
+  if (occupant) {
+    triggerBump(player, occupant, endPosition);
+    return;
+  }
+  if (spaceType === "S") {
+    narrate(`${player.name} landed on Soft water and gains another turn!`);
+    endMovementPhase(true);
+  } else if (spaceType === "H") {
+    player.missNextTurn = true;
+    narrate(`${player.name} landed on Hard water and will miss their next turn.`);
+    endMovementPhase(false);
+  } else {
+    endMovementPhase(false);
+  }
+}
+
+function getPlayerAt(position, excludeId) {
+  return players.find((p) => p.id !== excludeId && p.pos && p.pos.row === position.row && p.pos.col === position.col && p.pos.space === position.space);
+}
+
+function triggerBump(active, victim, position) {
+  narrate(`${active.name} bumped ${victim.name}! Choose a neutral space for relocation.`);
+  gamePhase = PHASES.BUMP_RELOCATE;
+  bumpContext = { activeId: active.id, victimId: victim.id };
+  if (victim.isCPU) {
+    chooseCpuBump(active, victim);
+  } else if (active.isCPU) {
+    chooseCpuBump(active, victim);
+  } else {
+    highlightNeutralSpaces((target) => {
+      relocatePlayer(victim, target);
+      allowOptionalRotation(victim);
+    });
+  }
+}
+
+function highlightNeutralSpaces(callback) {
+  if (!boardElement._grid) return;
+  const overlay = document.createElement("div");
+  overlay.className = "overlay-grid";
+  overlay.style.gridTemplateRows = boardElement._grid.style.gridTemplateRows;
+  overlay.style.gridTemplateColumns = boardElement._grid.style.gridTemplateColumns;
+  clearPlacementLayer();
+  placementLayer.appendChild(overlay);
+  placementLayer.style.pointerEvents = "auto";
+  const minRow = Number(boardElement.dataset.minRow || 0);
+  const minCol = Number(boardElement.dataset.minCol || 0);
+  boardState.forEach((boardTile) => {
+    const tileState = getTileState(boardTile);
+    const neutralSpaces = SIDES.concat("middle").filter((space) => tileState[space] === "N");
+    neutralSpaces.forEach((space) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = `bump-target target-${space} neutral`;
+      button.style.gridRowStart = boardTile.row - minRow + 1;
+      button.style.gridColumnStart = boardTile.col - minCol + 1;
+      button.dataset.space = space;
+      button.setAttribute("aria-label", `Relocate to ${space}`);
+      button.addEventListener("click", () => {
+        clearPlacementLayer();
+        callback({ row: boardTile.row, col: boardTile.col, space });
+      });
+      overlay.appendChild(button);
+    });
+  });
+}
+
+function relocatePlayer(player, position) {
+  player.pos = { ...position };
+  renderBoard();
+  renderTokens();
+  narrate(`${player.name} relocated to (${position.row}, ${position.col}) ${position.space}.`);
+}
+
+function allowOptionalRotation(targetPlayer) {
+  const tileKey = `${targetPlayer.pos.row},${targetPlayer.pos.col}`;
+  const boardTile = boardState.get(tileKey);
+  if (!boardTile) {
+    endMovementPhase(false);
+    return;
+  }
+  narrate(`You may rotate tile ${boardTile.base.tile_number} that ${targetPlayer.name} landed on.`);
+  const tileElement = findTileElement(tileKey);
+  const rotationHandler = () => {
+    rotateBoardTile(boardTile, 1);
+    updateTokenAfterRotation(targetPlayer, 1);
+    renderBoard();
+    renderTokens();
+  };
+  tileElement?.addEventListener("click", rotationHandler, { once: true });
+  endMovementPhase(false);
+}
+
+function updateTokenAfterRotation(player, steps) {
+  if (!player.pos) return;
+  const order = ["top", "right", "bottom", "left"];
+  let index = order.indexOf(player.pos.space);
+  if (index === -1) return;
+  index = (index + steps) % 4;
+  player.pos.space = order[index];
+}
+
+function endMovementPhase(repeatTurn) {
+  clearPlacementLayer();
+  gamePhase = PHASES.AWAITING_SHIFT;
+  awaitingConfirm = false;
+  pendingShift = null;
+  if (repeatTurn) {
+    narrate(`${currentPlayer().name} rolls again!`);
+  }
+  updateControls();
+  if (currentPlayer().isCPU) {
+    processCpuShift();
+  }
+}
+
+function endShiftPhase(skipped) {
+  narrate(skipped ? `${currentPlayer().name} skipped the shift.` : `${currentPlayer().name} completed the shift.`);
+  advanceTurn();
+}
+
+function advanceTurn() {
+  clearPlacementLayer();
+  awaitingConfirm = false;
+  pendingShift = null;
+  bumpContext = null;
+  let nextIndex = currentPlayerIndex;
+  do {
+    nextIndex = (nextIndex + 1) % players.length;
+    if (!players[nextIndex].missNextTurn) break;
+    players[nextIndex].missNextTurn = false;
+    narrate(`${players[nextIndex].name} misses this turn.`);
+  } while (nextIndex !== currentPlayerIndex);
+  currentPlayerIndex = nextIndex;
+  gamePhase = PHASES.AWAITING_ROLL;
+  highlightCurrentPlayer();
+  updateControls();
+  if (isCurrentPlayerCPU()) {
+    processCpuTurn();
+  }
+}
+
+function currentPlayer() {
+  return players[currentPlayerIndex];
+}
+
+function isCurrentPlayerCPU() {
+  return currentPlayer().isCPU;
+}
+
+function highlightCurrentPlayer() {
+  players.forEach((player, idx) => {
+    const token = playerTokens.get(player.id);
+    if (token) {
+      token.classList.toggle("active", idx === currentPlayerIndex);
+    }
+  });
+}
+
+function updateControls() {
+  rollBtn.disabled = gamePhase !== PHASES.AWAITING_ROLL || isCurrentPlayerCPU();
+  confirmPlacementBtn.classList.toggle("hidden", !awaitingConfirm);
+  skipShiftBtn.classList.toggle("hidden", isCurrentPlayerCPU() || gamePhase !== PHASES.AWAITING_SHIFT);
+}
+
+function clearAnnouncer() {
+  announcerLog.innerHTML = "";
+}
+
+function narrate(message, delay = 0) {
+  announcerQueue = announcerQueue.then(
+    () =>
+      new Promise((resolve) => {
+        setTimeout(() => {
+          const p = document.createElement("p");
+          p.textContent = message;
+          announcerLog.appendChild(p);
+          announcerLog.scrollTop = announcerLog.scrollHeight;
+          resolve();
+        }, delay);
+      })
+  );
+  return announcerQueue;
+}
+
+function onTileClicked(row, col) {
+  if (gamePhase === PHASES.AWAITING_SHIFT && currentPlayer().pos) {
+    if (!pendingShift) {
+      const tile = boardState.get(`${row},${col}`);
+      if (!tile) return;
+      pickupTile(tile);
+    } else if (pendingShift && pendingShift.tile) {
+      placeTileAt(row, col);
+    }
+  }
+}
+
+function pickupTile(tile) {
+  const key = `${tile.row},${tile.col}`;
+  if (!boardState.has(key)) return;
+  pendingShift = {
+    tile,
+    originRow: tile.row,
+    originCol: tile.col,
+    removedPlayers: getPlayersOnTile(tile.row, tile.col)
+  };
+  boardState.delete(key);
+  pendingShift.removedPlayers.forEach((player) => {
+    player.pos = null;
+  });
+  narrate(`${currentPlayer().name} picked up tile ${tile.base.tile_number}.`);
+  renderBoard();
+  renderTokens();
+  showPlacementOptions();
+}
+
+function getPlayersOnTile(row, col) {
+  return players.filter((p) => p.pos && p.pos.row === row && p.pos.col === col);
+}
+
+function showPlacementOptions() {
+  if (!pendingShift) return;
+  const options = computePlacementOptions(pendingShift.tile);
+  clearPlacementLayer();
+  const { minRow, maxRow, minCol, maxCol } = getBoardBounds(options);
+  renderBoard(options);
+  const rows = maxRow - minRow + 1;
+  const cols = maxCol - minCol + 1;
+  const overlay = document.createElement("div");
+  overlay.className = "board-grid";
+  overlay.style.gridTemplateRows = `repeat(${rows}, var(--tile-size))`;
+  overlay.style.gridTemplateColumns = `repeat(${cols}, var(--tile-size))`;
+  options.forEach((cell) => {
+    const cellDiv = document.createElement("div");
+    cellDiv.className = "placement-cell";
+    if (!cell.valid) cellDiv.classList.add("invalid");
+    if (cell.highlight) cellDiv.classList.add("highlight");
+    cellDiv.addEventListener("click", () => {
+      if (!cell.valid) return;
+      pendingShift.target = cell;
+      placeTileAt(cell.row, cell.col);
+    });
+    overlay.appendChild(cellDiv);
+  });
+  placementLayer.appendChild(overlay);
+  placementLayer.style.pointerEvents = "auto";
+}
+
+function computePlacementOptions(tile) {
+  const options = [];
+  const visited = new Set();
+  boardState.forEach((other) => {
+    const neighbors = [
+      { row: other.row - 1, col: other.col },
+      { row: other.row + 1, col: other.col },
+      { row: other.row, col: other.col - 1 },
+      { row: other.row, col: other.col + 1 }
+    ];
+    neighbors.forEach((n) => {
+      const key = `${n.row},${n.col}`;
+      if (boardState.has(key) || visited.has(key)) return;
+      visited.add(key);
+      const rotations = getValidRotations(tile, n.row, n.col);
+      options.push({ row: n.row, col: n.col, valid: rotations.length > 0, rotations });
+    });
+  });
+  return options;
+}
+
+function getValidRotations(tile, row, col) {
+  const valid = [];
+  for (let orientation = 0; orientation < 4; orientation++) {
+    const rotated = getTileState({ base: tile.base, orientation, row, col });
+    if (checkConnectivity(rotated)) {
+      valid.push(orientation);
+    }
+  }
+  return valid;
+}
+
+function checkConnectivity(tileState) {
+  const neighbors = [
+    { row: tileState.row - 1, col: tileState.col, side: "top" },
+    { row: tileState.row + 1, col: tileState.col, side: "bottom" },
+    { row: tileState.row, col: tileState.col - 1, side: "left" },
+    { row: tileState.row, col: tileState.col + 1, side: "right" }
   ];
-  const mimeType = mimeCandidates.find((type) => MediaRecorder.isTypeSupported(type));
-  if (!mimeType) {
-    alert("No supported MediaRecorder codec found in this browser.");
-    exportButton.disabled = false;
-    isExporting = false;
+  return neighbors.some((neighbor) => {
+    const boardTile = boardState.get(`${neighbor.row},${neighbor.col}`);
+    if (!boardTile) return false;
+    const neighborState = getTileState(boardTile);
+    const opposite = SIDES[(SIDES.indexOf(neighbor.side) + 2) % 4];
+    return tileState[neighbor.side] && neighborState[opposite];
+  });
+}
+
+function placeTileAt(row, col) {
+  if (!pendingShift) return;
+  const rotationOptions = getValidRotations(pendingShift.tile, row, col);
+  if (rotationOptions.length === 0) {
+    narrate("No valid orientation for that placement.");
     return;
   }
+  pendingShift.tile.row = row;
+  pendingShift.tile.col = col;
+  pendingShift.tile.orientation = rotationOptions[0];
+  boardState.set(`${row},${col}`, pendingShift.tile);
+  if (pendingShift.tile.base.tile_number === "3-4") {
+    finishRow = row;
+    finishCol = col;
+  }
+  narrate(`${currentPlayer().name} placed tile ${pendingShift.tile.base.tile_number} at (${row}, ${col}).`);
+  awaitingConfirm = true;
+  updateControls();
+  clearPlacementLayer();
+  renderBoard();
+  renderTokens();
+  confirmPlacementBtn.onclick = () => finalizePlacement(rotationOptions);
+}
 
-  const recorder = new MediaRecorder(stream, { mimeType });
-  const chunks = [];
-  const wasLooping = video.loop;
-  video.loop = false;
-
-  const stopRecording = () => {
-    if (recorder.state !== "inactive") {
-      recorder.stop();
-    }
-  };
-
-  recorder.ondataavailable = (event) => {
-    if (event.data && event.data.size > 0) {
-      chunks.push(event.data);
-    }
-  };
-
-  recorder.onstop = () => {
-    const blob = new Blob(chunks, { type: mimeType });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "glitch-art.webm";
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-
-    exportButton.disabled = false;
-    isExporting = false;
-    video.loop = wasLooping;
-    video.pause();
-    video.currentTime = 0;
-    if (wasLooping) {
-      video.play().catch(() => {});
-    }
-  };
-
-  recorder.onerror = (event) => {
-    console.error("MediaRecorder error", event.error);
-    stopRecording();
-    exportButton.disabled = false;
-    isExporting = false;
-    video.loop = wasLooping;
-    video.pause();
-    video.currentTime = 0;
-  };
-
-  const handleEnded = () => {
-    video.removeEventListener("ended", handleEnded);
-    stopRecording();
-  };
-
-  video.addEventListener("ended", handleEnded, { once: true });
-
-  recorder.start();
-  video.pause();
-  video.currentTime = 0;
-  const playPromise = video.play();
-  if (playPromise) {
-    playPromise.catch((err) => {
-      console.warn("Autoplay prevented during export", err);
-      stopRecording();
+function finalizePlacement(rotations) {
+  confirmPlacementBtn.onclick = null;
+  awaitingConfirm = false;
+  updateControls();
+  if (pendingShift && pendingShift.removedPlayers) {
+    pendingShift.removedPlayers.forEach((player) => {
+      highlightNeutralSpaces((pos) => {
+        player.pos = pos;
+        renderBoard();
+        renderTokens();
+        endShiftPhase(false);
+      });
     });
+  } else {
+    endShiftPhase(false);
   }
 }
 
-function setupDragAndDrop() {
-  ["dragenter", "dragover"].forEach((type) => {
-    dropZone.addEventListener(type, (event) => {
-      event.preventDefault();
-      event.dataTransfer.dropEffect = "copy";
-      dropZone.classList.add("dragover");
-    });
-  });
+function confirmShiftPlacement() {
+  if (!pendingShift) return;
+  finalizePlacement([pendingShift.tile.orientation]);
+}
 
-  ["dragleave", "drop"].forEach((type) => {
-    dropZone.addEventListener(type, (event) => {
-      event.preventDefault();
-      dropZone.classList.remove("dragover");
-    });
-  });
+function rotateBoardTile(tile, steps) {
+  tile.orientation = (tile.orientation + steps) % 4;
+}
 
-  dropZone.addEventListener("drop", (event) => {
-    const files = event.dataTransfer.files;
-    if (files && files.length > 0) {
-      handleFileSelection(files[0]);
-    }
+function endGame(player) {
+  gamePhase = PHASES.GAME_OVER;
+  narrate(`${player.name} reached the Finish!`);
+  victoryTitle.textContent = `${player.name} Wins!`;
+  victoryMessage.textContent = `Congratulations to ${player.name} for navigating the Culligan network first.`;
+  victoryModal.classList.remove("hidden");
+}
+
+function processCpuTurn() {
+  if (gamePhase !== PHASES.AWAITING_ROLL) return;
+  rollBtn.disabled = true;
+  setTimeout(() => {
+    onRollDice();
+  }, 1000);
+}
+
+function chooseCpuMovement(paths) {
+  paths.sort((a, b) => scoreMovementPath(b) - scoreMovementPath(a));
+  const best = paths[0];
+  narrate(`CPU evaluating ${paths.length} paths...`, 500).then(() => {
+    executeMovement(best);
   });
 }
 
-function setupControls() {
-  fileInput.addEventListener("change", () => {
-    const file = fileInput.files?.[0];
-    handleFileSelection(file);
-  });
-
-  exportButton.addEventListener("click", () => {
-    if (!isExporting) {
-      exportVideo();
-    }
-  });
-
-  window.addEventListener("beforeunload", () => {
-    if (currentObjectUrl) {
-      URL.revokeObjectURL(currentObjectUrl);
-    }
-  });
-
-  document.addEventListener("visibilitychange", () => {
-    if (document.hidden) {
-      stopRendering();
-    } else if (video.src) {
-      startRendering();
-    }
-  });
+function scoreMovementPath(path) {
+  const end = path[path.length - 1];
+  const distance = manhattanDistance(end, { row: finishRow, col: finishCol });
+  return -distance;
 }
 
-initEffectUI();
-setupDragAndDrop();
-setupControls();
+function chooseCpuBump(active, victim) {
+  const neutrals = [];
+  boardState.forEach((tile) => {
+    const state = getTileState(tile);
+    SIDES.concat("middle").forEach((space) => {
+      if (state[space] === "N") {
+        neutrals.push({ row: tile.row, col: tile.col, space });
+      }
+    });
+  });
+  const target = neutrals[0];
+  relocatePlayer(victim, target);
+  endMovementPhase(false);
+}
+
+function processCpuShift() {
+  setTimeout(() => {
+    endShiftPhase(true);
+  }, 800);
+}
+
+function manhattanDistance(a, b) {
+  return Math.abs(a.row - b.row) + Math.abs(a.col - b.col);
+}
+
+function chooseCpuShift() {}
+
+function enableShiftSkip() {}
+
+function onCpuSkip() {}
+
+function allowRotationForPlacement(rotations) {}
 

--- a/style.css
+++ b/style.css
@@ -1,13 +1,15 @@
 :root {
-  color-scheme: dark light;
-  --bg: #0a0a0f;
-  --panel: rgba(255, 255, 255, 0.04);
-  --accent: #ff4ecd;
-  --text: #f3f3f3;
-  --muted: #8f8f9b;
-  --border: rgba(255, 255, 255, 0.12);
-  --shadow: rgba(15, 15, 30, 0.45);
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --soft: #48bb78;
+  --neutral: #63b3ed;
+  --hard: #b794f4;
+  --tile-size: 78px;
+  --slot-size: 20px;
+  --slot-offset: calc(14px + var(--slot-size) / 2);
+  --token-size: 2.1rem;
+  --panel-bg: #ffffff;
+  --panel-border: #cbd5f5;
+  --panel-shadow: 0 4px 10px rgba(15, 23, 42, 0.12);
+  --tile-number: #4a5568;
 }
 
 * {
@@ -17,249 +19,459 @@
 body {
   margin: 0;
   min-height: 100vh;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background: #f1f5f9;
+  color: #1a202c;
   display: flex;
-  flex-direction: column;
-  background: radial-gradient(circle at top left, rgba(255, 78, 205, 0.12), transparent 45%),
-    radial-gradient(circle at bottom right, rgba(78, 206, 255, 0.12), transparent 40%), var(--bg);
-  color: var(--text);
-}
-
-.app-header,
-.app-footer {
-  text-align: center;
-  padding: 1.5rem 1rem;
-  background: rgba(5, 5, 10, 0.6);
-  border-bottom: 1px solid var(--border);
-  backdrop-filter: blur(12px);
-}
-
-.app-footer {
-  border-top: 1px solid var(--border);
-  border-bottom: none;
-  margin-top: auto;
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-
-.tagline {
-  color: var(--muted);
-  margin: 0.25rem 0 0;
-}
-
-.app-main {
-  display: flex;
-  flex: 1;
-  gap: 1.5rem;
-  padding: 1.5rem;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: center;
-}
-
-.control-panel {
-  width: min(360px, 100%);
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  padding: 1.5rem;
-  box-shadow: 0 20px 40px var(--shadow);
-  backdrop-filter: blur(18px);
-}
-
-.file-controls {
-  display: flex;
-  gap: 0.75rem;
-  margin-bottom: 1.5rem;
-  align-items: center;
-}
-
-.file-picker {
-  position: relative;
-  overflow: hidden;
-  display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
-  padding: 0.6rem 1.4rem;
-  background: var(--accent);
-  color: white;
-  cursor: pointer;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  box-shadow: 0 10px 24px rgba(255, 78, 205, 0.35);
-}
-
-.file-picker input[type="file"] {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-  cursor: pointer;
+  padding: 1.5rem;
 }
 
 button {
-  padding: 0.6rem 1.2rem;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--text);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  background: #2563eb;
+  border: 1px solid #1d4ed8;
+  color: #ffffff;
+  padding: 0.5rem 1.1rem;
+  border-radius: 6px;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-button.primary {
-  background: linear-gradient(135deg, #ff4ecd, #4ec6ff);
-  color: #0c0612;
-  box-shadow: 0 12px 28px rgba(78, 198, 255, 0.3);
+  font-size: 1rem;
 }
 
 button:disabled {
-  opacity: 0.4;
+  opacity: 0.45;
   cursor: not-allowed;
-  box-shadow: none;
 }
 
-button:not(:disabled):hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
+.hidden {
+  display: none !important;
 }
 
-.effects {
+.game {
+  display: flex;
+  gap: 1.5rem;
+  width: min(1100px, 100%);
+  flex-wrap: wrap;
+}
+
+.board-wrapper {
+  position: relative;
+  flex: 1 1 600px;
+  min-height: 520px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: #e2e8f0;
+  border: 1px solid #cbd5f5;
+  border-radius: 8px;
+}
+
+#board-background {
+  position: absolute;
+  inset: 1.5rem;
+  border: 1px dashed #cbd5f5;
+  background: repeating-linear-gradient(
+      0deg,
+      rgba(148, 163, 184, 0.15) 0,
+      rgba(148, 163, 184, 0.15) 12px,
+      transparent 12px,
+      transparent 24px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(148, 163, 184, 0.15) 0,
+      rgba(148, 163, 184, 0.15) 12px,
+      transparent 12px,
+      transparent 24px
+    );
+  border-radius: 4px;
+}
+
+#board,
+#placement-layer {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+}
+
+#board {
+  pointer-events: auto;
+}
+
+#placement-layer {
+  pointer-events: none;
+}
+
+.board-grid {
+  display: grid;
+  position: relative;
+  gap: 4px;
+}
+
+.empty-cell {
+  width: var(--tile-size);
+  height: var(--tile-size);
+  border: 1px dashed #cbd5f5;
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.board-tile {
+  width: var(--tile-size);
+  height: var(--tile-size);
+  background: #ffffff;
+  border: 1px solid #cbd5f5;
+  border-radius: 4px;
+  position: relative;
+  overflow: hidden;
+  pointer-events: auto;
+}
+
+.board-tile .segments {
+  position: absolute;
+  inset: 14px;
+}
+
+.tile-number {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  font-size: 0.62rem;
+  color: var(--tile-number);
+}
+
+.slot {
+  position: absolute;
+  width: var(--slot-size);
+  height: var(--slot-size);
+  border: 1px solid #94a3b8;
+  background: #edf2f7;
+  border-radius: 2px;
+}
+
+.slot.empty {
+  background: transparent;
+  border-style: dashed;
+  opacity: 0.5;
+}
+
+.slot.soft {
+  background: rgba(72, 187, 120, 0.2);
+  border-color: #48bb78;
+}
+
+.slot.neutral {
+  background: rgba(99, 179, 237, 0.2);
+  border-color: #63b3ed;
+}
+
+.slot.hard {
+  background: rgba(183, 148, 244, 0.2);
+  border-color: #b794f4;
+}
+
+.slot.finish {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.55rem;
+  font-weight: 600;
+  border-style: dashed;
+}
+
+.slot-top {
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, 0);
+}
+
+.slot-bottom {
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, 0);
+}
+
+.slot-left {
+  left: 0;
+  top: 50%;
+  transform: translate(0, -50%);
+}
+
+.slot-right {
+  right: 0;
+  top: 50%;
+  transform: translate(0, -50%);
+}
+
+.slot-middle {
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.pipe {
+  position: absolute;
+  background: #94a3b8;
+  border-radius: 3px;
+}
+
+.pipe.soft {
+  background: #48bb78;
+}
+
+.pipe.neutral {
+  background: #63b3ed;
+}
+
+.pipe.hard {
+  background: #b794f4;
+}
+
+.pipe-top,
+.pipe-bottom {
+  width: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.pipe-top {
+  top: calc(var(--slot-size) / 2);
+  height: calc(50% - var(--slot-size) / 2);
+}
+
+.pipe-bottom {
+  bottom: calc(var(--slot-size) / 2);
+  height: calc(50% - var(--slot-size) / 2);
+}
+
+.pipe-left,
+.pipe-right {
+  height: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.pipe-left {
+  left: calc(var(--slot-size) / 2);
+  width: calc(50% - var(--slot-size) / 2);
+}
+
+.pipe-right {
+  right: calc(var(--slot-size) / 2);
+  width: calc(50% - var(--slot-size) / 2);
+}
+
+.token {
+  position: absolute;
+  width: var(--token-size);
+  height: var(--token-size);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: #1a202c;
+  border: 2px solid rgba(17, 24, 39, 0.25);
+  background: currentColor;
+  transform: translate(-50%, -50%);
+}
+
+.token.active {
+  outline: 3px solid gold;
+  transform: translate(-50%, -50%) scale(1.05);
+}
+
+.side-panel {
+  flex: 1 1 260px;
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: 1.25rem;
 }
 
-.effect-group {
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 12px;
+.announcer,
+.controls {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
   padding: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  box-shadow: var(--panel-shadow);
 }
 
-.effect-group.active {
-  border-color: rgba(255, 78, 205, 0.45);
-  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
-}
-
-.effect-description {
-  margin: 0 0 0.8rem;
-  color: var(--muted);
-  font-size: 0.85rem;
+.announcer-log {
+  min-height: 220px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 0.75rem;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  font-size: 0.95rem;
   line-height: 1.45;
 }
 
-.effect-header {
+.announcer-log p {
+  margin: 0 0 0.75rem;
+}
+
+.dice-display {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
   gap: 0.5rem;
-  margin-bottom: 0.8rem;
-}
-
-.effect-header h3 {
-  margin: 0;
-  font-size: 1rem;
-  letter-spacing: 0.02em;
-}
-
-.effect-header label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-size: 0.9rem;
-  cursor: pointer;
-  color: var(--muted);
-}
-
-.effect-sliders {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.slider-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  font-size: 0.85rem;
-}
-
-.slider-row input[type="range"] {
-  flex: 1;
-}
-
-.slider-value {
-  width: 3.5rem;
-  text-align: right;
-  color: var(--muted);
-  font-variant-numeric: tabular-nums;
-}
-
-.preview-panel {
-  flex: 1 1 420px;
-  min-height: 360px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.drop-zone {
-  position: relative;
-  width: min(100%, 800px);
-  aspect-ratio: 16 / 9;
-  border: 2px dashed rgba(255, 255, 255, 0.25);
-  border-radius: 20px;
-  display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.04);
-  overflow: hidden;
-  transition: border-color 0.2s ease;
+  font-size: 1.75rem;
+  background: #ffffff;
+  border: 1px solid #cbd5f5;
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
 }
 
-.drop-zone.dragover {
-  border-color: var(--accent);
+.dice-display .sum {
+  font-size: 1.1rem;
+  color: #4a5568;
 }
 
-#output-canvas {
-  width: 100%;
-  height: 100%;
-  display: block;
-  background: #000;
+.control-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.drop-hint {
+.placement-cell {
+  width: var(--tile-size);
+  height: var(--tile-size);
+  border: 2px dashed rgba(99, 179, 237, 0.6);
+  background: rgba(99, 179, 237, 0.18);
+  border-radius: 4px;
+  pointer-events: auto;
+}
+
+.placement-cell.invalid {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.placement-cell.highlight {
+  border-color: rgba(72, 187, 120, 0.8);
+  background: rgba(72, 187, 120, 0.18);
+}
+
+.overlay-grid {
   position: absolute;
   inset: 0;
+  display: grid;
+  pointer-events: auto;
+  z-index: 6;
+}
+
+.bump-target {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  position: relative;
+}
+
+.bump-target::after {
+  content: "";
+  position: absolute;
+  width: var(--slot-size);
+  height: var(--slot-size);
+  border-radius: 2px;
+  border: 2px solid #63b3ed;
+  background: rgba(99, 179, 237, 0.18);
+  top: var(--slot-offset);
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.bump-target.target-bottom::after {
+  top: calc(100% - var(--slot-offset));
+}
+
+.bump-target.target-left::after {
+  left: var(--slot-offset);
+  top: 50%;
+}
+
+.bump-target.target-right::after {
+  left: calc(100% - var(--slot-offset));
+  top: 50%;
+}
+
+.bump-target.target-middle::after {
+  top: 50%;
+}
+
+.bump-target.soft::after {
+  border-color: #48bb78;
+  background: rgba(72, 187, 120, 0.2);
+}
+
+.bump-target.hard::after {
+  border-color: #b794f4;
+  background: rgba(183, 148, 244, 0.2);
+}
+
+.menu-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(226, 232, 240, 0.9);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: rgba(255, 255, 255, 0.35);
-  font-size: 1.15rem;
-  letter-spacing: 0.06em;
-  pointer-events: none;
-  text-transform: uppercase;
+  z-index: 10;
 }
 
-.drop-zone.loaded .drop-hint {
-  opacity: 0;
+.menu-card {
+  background: #ffffff;
+  border: 1px solid #cbd5f5;
+  border-radius: 6px;
+  padding: 2rem;
+  box-shadow: var(--panel-shadow);
+  text-align: center;
+  width: min(420px, 90%);
 }
 
-@media (max-width: 800px) {
-  .app-main {
+.menu-buttons {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 11;
+}
+
+.modal-card {
+  background: #ffffff;
+  border: 1px solid #cbd5f5;
+  border-radius: 6px;
+  padding: 1.5rem 2rem;
+  text-align: center;
+  box-shadow: var(--panel-shadow);
+}
+
+@media (max-width: 900px) {
+  body {
     padding: 1rem;
   }
 
-  .control-panel {
-    width: 100%;
+  .game {
+    flex-direction: column;
+    align-items: stretch;
   }
 
-  .drop-zone {
-    aspect-ratio: 4 / 3;
+  .board-wrapper {
+    width: 100%;
+    min-height: 420px;
+  }
+
+  .side-panel {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- replace the dark, glossy board presentation with a flat neutral layout to make the tile grid easier to read
- simplify tile, token, and placement highlight styles while preserving the required color coding and finish label
- restyle the menu, announcer, and controls with light panels so the interface matches the stripped-down board

## Testing
- Not run (manual testing recommended)


------
https://chatgpt.com/codex/tasks/task_e_68db6bf7401083299c54bd95ffc0d4f9