### PR TITLE
Improve shift interaction overlays and board scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
         <div class="control-buttons">
           <button id="roll-btn">Roll Dice</button>
           <button id="confirm-placement" class="hidden">Confirm Placement</button>
+          <button id="rotate-placement" class="hidden">Rotate Placement</button>
           <button id="skip-shift" class="hidden">Skip Shift</button>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -1,41 +1,59 @@
 const TILE_DATA = [
-  { "tile_number": "1-1", "top": "S", "left": "", "middle": "N", "right": "N", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
-  { "tile_number": "1-2", "top": "", "left": "", "middle": "N", "right": "N", "bottom": "N", "connections": { "middle": ["right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
-  { "tile_number": "1-3", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
-  { "tile_number": "1-4", "top": "", "left": "S", "middle": "S", "right": "S", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
-  { "tile_number": "1-5", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
-  { "tile_number": "1-6", "top": "", "left": "H", "middle": "H", "right": "", "bottom": "H", "connections": { "left": ["middle"], "middle": ["left", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "2-1", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "2-2", "top": "S", "left": "S", "middle": "N", "right": "H", "bottom": "H", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
-  { "tile_number": "2-3", "top": "", "left": "", "middle": "N", "right": "N", "bottom": "N", "connections": { "middle": ["right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
-  { "tile_number": "2-4", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
-  { "tile_number": "2-5", "top": "", "left": "N", "middle": "N", "right": "", "bottom": "N", "connections": { "left": ["middle"], "middle": ["left", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "2-6", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "3-1", "top": "H", "left": "", "middle": "H", "right": "", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "3-2", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "3-3", "top": "S", "left": "S", "middle": "N", "right": "H", "bottom": "H", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
-  { "tile_number": "3-4", "top": "", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "middle": ["bottom"], "bottom": ["middle"] } },
-  { "tile_number": "3-5", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "3-6", "top": "S", "left": "", "middle": "S", "right": "", "bottom": "S", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "4-1", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "4-2", "top": "H", "left": "", "middle": "H", "right": "", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "4-3", "top": "N", "left": "", "middle": "N", "right": "N", "bottom": "", "connections": { "top": ["middle"], "middle": ["top", "right"], "right": ["middle"] } },
-  { "tile_number": "4-4", "top": "H", "left": "H", "middle": "N", "right": "S", "bottom": "S", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
-  { "tile_number": "4-5", "top": "H", "left": "", "middle": "H", "right": "", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "4-6", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "5-1", "top": "S", "left": "", "middle": "S", "right": "", "bottom": "S", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "5-2", "top": "N", "left": "", "middle": "N", "right": "N", "bottom": "", "connections": { "top": ["middle"], "middle": ["top", "right"], "right": ["middle"] } },
-  { "tile_number": "5-3", "top": "", "left": "S", "middle": "S", "right": "S", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
-  { "tile_number": "5-4", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
-  { "tile_number": "5-5", "top": "H", "left": "H", "middle": "N", "right": "S", "bottom": "S", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
-  { "tile_number": "5-6", "top": "H", "left": "", "middle": "H", "right": "", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
-  { "tile_number": "6-1", "top": "N", "left": "", "middle": "N", "right": "N", "bottom": "", "connections": { "top": ["middle"], "middle": ["top", "right"], "right": ["middle"] } },
-  { "tile_number": "6-2", "top": "", "left": "H", "middle": "H", "right": "H", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
-  { "tile_number": "6-3", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
-  { "tile_number": "6-4", "top": "", "left": "S", "middle": "S", "right": "S", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
-  { "tile_number": "6-5", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
-  { "tile_number": "6-6", "top": "H", "left": "H", "middle": "N", "right": "S", "bottom": "S", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } }
+{ "tile_number": "1-1", "top": "S", "left": "", "middle": "N", "right": "N", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+{ "tile_number": "1-2", "top": "", "left": "", "middle": "N", "right": "N", "bottom": "N", "connections": { "middle": ["right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+{ "tile_number": "1-3", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+{ "tile_number": "1-4", "top": "", "left": "S", "middle": "S", "right": "S", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+{ "tile_number": "1-5", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+{ "tile_number": "1-6", "top": "", "left": "H", "middle": "H", "right": "", "bottom": "H", "connections": { "left": ["middle"], "middle": ["left", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "2-1", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "2-2", "top": "S", "left": "S", "middle": "N", "right": "H", "bottom": "H", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+{ "tile_number": "2-3", "top": "", "left": "", "middle": "N", "right": "N", "bottom": "N", "connections": { "middle": ["right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+{ "tile_number": "2-4", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+{ "tile_number": "2-5", "top": "", "left": "N", "middle": "N", "right": "", "bottom": "N", "connections": { "left": ["middle"], "middle": ["left", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "2-6", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "3-1", "top": "H", "left": "", "middle": "H", "right": "", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "3-2", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "3-3", "top": "S", "left": "S", "middle": "N", "right": "H", "bottom": "H", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+{ "tile_number": "3-4", "top": "", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "middle": ["bottom"], "bottom": ["middle"] } },
+{ "tile_number": "3-5", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "3-6", "top": "S", "left": "", "middle": "S", "right": "", "bottom": "S", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "4-1", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "4-2", "top": "H", "left": "", "middle": "H", "right": "", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "4-3", "top": "N", "left": "", "middle": "N", "right": "N", "bottom": "", "connections": { "top": ["middle"], "middle": ["top", "right"], "right": ["middle"] } },
+{ "tile_number": "4-4", "top": "H", "left": "H", "middle": "N", "right": "S", "bottom": "S", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+{ "tile_number": "4-5", "top": "H", "left": "", "middle": "H", "right": "", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "4-6", "top": "N", "left": "", "middle": "N", "right": "", "bottom": "N", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "5-1", "top": "S", "left": "", "middle": "S", "right": "", "bottom": "S", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "5-2", "top": "N", "left": "", "middle": "N", "right": "N", "bottom": "", "connections": { "top": ["middle"], "middle": ["top", "right"], "right": ["middle"] } },
+{ "tile_number": "5-3", "top": "", "left": "S", "middle": "S", "right": "S", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+{ "tile_number": "5-4", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+{ "tile_number": "5-5", "top": "H", "left": "H", "middle": "N", "right": "S", "bottom": "S", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } },
+{ "tile_number": "5-6", "top": "H", "left": "", "middle": "H", "right": "", "bottom": "H", "connections": { "top": ["middle"], "middle": ["top", "bottom"], "bottom": ["middle"] } },
+{ "tile_number": "6-1", "top": "N", "left": "", "middle": "N", "right": "N", "bottom": "", "connections": { "top": ["middle"], "middle": ["top", "right"], "right": ["middle"] } },
+{ "tile_number": "6-2", "top": "", "left": "H", "middle": "H", "right": "H", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+{ "tile_number": "6-3", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+{ "tile_number": "6-4", "top": "", "left": "S", "middle": "S", "right": "S", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+{ "tile_number": "6-5", "top": "", "left": "N", "middle": "N", "right": "N", "bottom": "", "connections": { "left": ["middle"], "middle": ["left", "right"], "right": ["middle"] } },
+{ "tile_number": "6-6", "top": "H", "left": "H", "middle": "N", "right": "S", "bottom": "S", "connections": { "top": ["middle"], "left": ["middle"], "middle": ["top", "left", "right", "bottom"], "right": ["middle"], "bottom": ["middle"] } }
 ];
+
+const SIDES = ["top", "right", "bottom", "left"];
+const SPACE_POSITIONS = {
+  top: { x: 0.5, y: 0.15 },
+  right: { x: 0.85, y: 0.5 },
+  bottom: { x: 0.5, y: 0.85 },
+  left: { x: 0.15, y: 0.5 },
+  middle: { x: 0.5, y: 0.5 }
+};
+const PHASES = {
+  AWAITING_ROLL: "AWAITING_ROLL",
+  AWAITING_MOVE: "AWAITING_MOVE",
+  AWAITING_SHIFT: "AWAITING_SHIFT",
+  BUMP_RELOCATE: "BUMP_RELOCATE",
+  GAME_OVER: "GAME_OVER"
+};
+
+const PLAYER_COLORS = ["#ef4444", "#3b82f6", "#10b981", "#f97316"];
 
 const menuOverlay = document.getElementById("menu");
 const gameContainer = document.getElementById("game");
@@ -45,42 +63,31 @@ const announcerLog = document.getElementById("announcer-log");
 const diceDisplay = document.getElementById("dice-display");
 const rollBtn = document.getElementById("roll-btn");
 const confirmPlacementBtn = document.getElementById("confirm-placement");
+const rotatePlacementBtn = document.getElementById("rotate-placement");
 const skipShiftBtn = document.getElementById("skip-shift");
 const victoryModal = document.getElementById("victory-modal");
 const victoryTitle = document.getElementById("victory-title");
 const victoryMessage = document.getElementById("victory-message");
 const restartBtn = document.getElementById("restart-btn");
 
-const PLAYER_COLORS = ["#f87171", "#38bdf8", "#facc15", "#a78bfa"];
-const SPACE_POSITIONS = {
-  top: { x: 0.5, y: 0.12 },
-  right: { x: 0.84, y: 0.5 },
-  bottom: { x: 0.5, y: 0.88 },
-  left: { x: 0.16, y: 0.5 },
-  middle: { x: 0.5, y: 0.5 }
+const state = {
+  boardState: new Map(),
+  players: [],
+  playerTokens: new Map(),
+  currentPlayerIndex: 0,
+  gamePhase: PHASES.AWAITING_ROLL,
+  finishRow: 2,
+  finishCol: 3,
+  dice: { die1: 1, die2: 1 },
+  pendingShift: null,
+  bumpContext: null,
+  awaitingConfirm: false,
+  cpuEnabled: false,
+  announcerQueue: Promise.resolve(),
+  lastBounds: { minRow: 0, maxRow: 5, minCol: 0, maxCol: 5 },
+  boardScale: 1,
+  extraTurnQueued: false
 };
-const SIDES = ["top", "right", "bottom", "left"];
-const PHASES = {
-  AWAITING_ROLL: "AWAITING_ROLL",
-  AWAITING_MOVE: "AWAITING_MOVE",
-  AWAITING_SHIFT: "AWAITING_SHIFT",
-  BUMP_RELOCATE: "BUMP_RELOCATE",
-  GAME_OVER: "GAME_OVER"
-};
-
-let boardState = new Map();
-let players = [];
-let playerTokens = new Map();
-let currentPlayerIndex = 0;
-let gamePhase = PHASES.AWAITING_ROLL;
-let finishRow = 2;
-let finishCol = 3;
-let diceResult = { die1: 1, die2: 1 };
-let pendingShift = null;
-let bumpContext = null;
-let announcerQueue = Promise.resolve();
-let cpuEnabled = false;
-let awaitingConfirm = false;
 
 const menuButtons = document.querySelectorAll(".menu-buttons button");
 menuButtons.forEach((btn) => {
@@ -88,16 +95,19 @@ menuButtons.forEach((btn) => {
     if (btn.dataset.mode === "cpu") {
       startGame(2, true);
     } else {
-      startGame(Number(btn.dataset.players || 1), false);
+      startGame(Number(btn.dataset.players || "1"), false);
     }
   });
 });
 
 rollBtn.addEventListener("click", onRollDice);
-confirmPlacementBtn.addEventListener("click", confirmShiftPlacement);
+confirmPlacementBtn.addEventListener("click", () => confirmShiftPlacement());
+rotatePlacementBtn.addEventListener("click", () => rotatePlacedTile());
 skipShiftBtn.addEventListener("click", () => {
-  if (isCurrentPlayerCPU()) return;
-  endShiftPhase(false);
+  if (currentPlayer().isCPU) return;
+  narrate(`${currentPlayer().name} skips the shift.`);
+  clearShiftHighlights();
+  endShiftPhase(true);
 });
 restartBtn.addEventListener("click", () => {
   victoryModal.classList.add("hidden");
@@ -108,30 +118,33 @@ restartBtn.addEventListener("click", () => {
 displayDice(1, 1);
 
 function startGame(playerCount, withCpu) {
-  cpuEnabled = withCpu;
-  boardState = new Map();
-  players = [];
-  playerTokens = new Map();
-  currentPlayerIndex = 0;
-  gamePhase = PHASES.AWAITING_ROLL;
-  finishRow = 2;
-  finishCol = 3;
-  diceResult = { die1: 1, die2: 1 };
-  pendingShift = null;
-  bumpContext = null;
-  awaitingConfirm = false;
+  state.boardState = new Map();
+  state.players = [];
+  state.playerTokens = new Map();
+  state.currentPlayerIndex = 0;
+  state.gamePhase = PHASES.AWAITING_ROLL;
+  state.finishRow = 2;
+  state.finishCol = 3;
+  state.dice = { die1: 1, die2: 1 };
+  state.pendingShift = null;
+  state.bumpContext = null;
+  state.awaitingConfirm = false;
+  state.cpuEnabled = withCpu;
+  state.extraTurnQueued = false;
+  state.boardScale = 1;
+  announcerLog.innerHTML = "";
   placementLayer.innerHTML = "";
-  clearAnnouncer();
+  boardElement.innerHTML = "";
   buildInitialBoard();
   createPlayers(playerCount, withCpu);
   renderBoard();
   renderTokens();
-  highlightCurrentPlayer();
   updateControls();
+  highlightCurrentPlayer();
   menuOverlay.classList.add("hidden");
   gameContainer.classList.remove("hidden");
-  narrate(`Welcome to Hey Culligan Man! ${players.length} player game ready.`);
-  if (isCurrentPlayerCPU()) {
+  narrate(`Welcome to Hey Culligan Man! ${playerCount} player game ready.`);
+  if (currentPlayer().isCPU) {
     processCpuTurn();
   }
 }
@@ -140,16 +153,17 @@ function buildInitialBoard() {
   for (let r = 0; r < 6; r++) {
     for (let c = 0; c < 6; c++) {
       const tileNumber = `${r + 1}-${c + 1}`;
-      const baseTile = TILE_DATA.find((t) => t.tile_number === tileNumber);
-      if (!baseTile) continue;
-      const tileState = createBoardTile(baseTile, 0, r, c);
-      boardState.set(`${r},${c}`, tileState);
+      const base = TILE_DATA.find((t) => t.tile_number === tileNumber);
+      if (!base) continue;
+      const tile = createBoardTile(base, r, c, 0);
+      state.boardState.set(`${r},${c}`, tile);
     }
   }
+  state.lastBounds = { minRow: 0, maxRow: 5, minCol: 0, maxCol: 5 };
 }
 
-function createPlayers(playerCount, withCpu) {
-  for (let i = 0; i < playerCount; i++) {
+function createPlayers(count, withCpu) {
+  for (let i = 0; i < count; i++) {
     const isCpu = withCpu && i === 1;
     const player = {
       id: i + 1,
@@ -159,24 +173,28 @@ function createPlayers(playerCount, withCpu) {
       isCPU: isCpu,
       missNextTurn: false
     };
-    players.push(player);
+    state.players.push(player);
     const token = document.createElement("div");
     token.className = "token";
     token.style.background = player.color;
     token.textContent = `${player.id}`;
     token.dataset.player = player.id;
     boardElement.appendChild(token);
-    playerTokens.set(player.id, token);
+    state.playerTokens.set(player.id, token);
   }
 }
 
-function createBoardTile(baseTile, orientation, row, col) {
+function createBoardTile(baseTile, row, col, orientation) {
   return {
-    base: structuredClone(baseTile),
-    orientation,
+    base: deepClone(baseTile),
     row,
-    col
+    col,
+    orientation
   };
+}
+
+function deepClone(obj) {
+  return JSON.parse(JSON.stringify(obj));
 }
 
 function getTileState(boardTile) {
@@ -186,24 +204,28 @@ function getTileState(boardTile) {
     row: boardTile.row,
     col: boardTile.col,
     orientation,
-    top: base.top,
-    right: base.right,
-    bottom: base.bottom,
-    left: base.left,
+    top: "",
+    right: "",
+    bottom: "",
+    left: "",
     middle: base.middle,
     connections: {}
   };
-  for (let i = 0; i < SIDES.length; i++) {
-    const side = SIDES[i];
-    const baseSide = SIDES[(i - orientation + 4) % 4];
+  SIDES.forEach((side, idx) => {
+    const baseSide = SIDES[(idx - orientation + 4) % 4];
     rotated[side] = base[baseSide];
-  }
-  rotated.middle = base.middle;
-  const points = ["top", "right", "bottom", "left", "middle"];
-  points.forEach((point) => {
-    if (!base.connections[point]) return;
-    const newPoint = rotatePoint(point, orientation);
-    rotated.connections[newPoint] = base.connections[point].map((p) => rotatePoint(p, orientation));
+  });
+  Object.entries(base.connections).forEach(([from, targets]) => {
+    const rotatedFrom = rotatePoint(from, orientation);
+    const rotatedTargets = targets.map((t) => rotatePoint(t, orientation));
+    if (!rotated.connections[rotatedFrom]) {
+      rotated.connections[rotatedFrom] = [];
+    }
+    rotatedTargets.forEach((target) => {
+      if (!rotated.connections[rotatedFrom].includes(target)) {
+        rotated.connections[rotatedFrom].push(target);
+      }
+    });
   });
   return rotated;
 }
@@ -216,39 +238,46 @@ function rotatePoint(point, orientation) {
 }
 
 function renderBoard(extraCells = []) {
-  boardElement.innerHTML = "";
-  const { minRow, maxRow, minCol, maxCol } = getBoardBounds(extraCells);
-  const rows = maxRow - minRow + 1;
-  const cols = maxCol - minCol + 1;
-  const boardGrid = document.createElement("div");
-  boardGrid.className = "board-grid";
-  boardGrid.style.gridTemplateRows = `repeat(${rows}, var(--tile-size))`;
-  boardGrid.style.gridTemplateColumns = `repeat(${cols}, var(--tile-size))`;
-  const tileElements = new Map();
+  const bounds = getBoardBounds(extraCells);
+  state.lastBounds = bounds;
+  const rows = bounds.maxRow - bounds.minRow + 1;
+  const cols = bounds.maxCol - bounds.minCol + 1;
+  const grid = document.createElement("div");
+  grid.className = "board-grid";
+  grid.style.display = "grid";
+  grid.style.gridTemplateRows = `repeat(${rows}, 72px)`;
+  grid.style.gridTemplateColumns = `repeat(${cols}, 72px)`;
+  grid.style.gap = "6px";
+  const maxDim = Math.max(rows, cols);
+  const scale = Math.min(1, 6 / maxDim);
+  state.boardScale = scale;
+  grid.style.transform = `scale(${scale})`;
+  grid.style.transformOrigin = "center center";
+  grid.style.margin = "0 auto";
 
-  for (let r = minRow; r <= maxRow; r++) {
-    for (let c = minCol; c <= maxCol; c++) {
+  const tileElements = new Map();
+  for (let r = bounds.minRow; r <= bounds.maxRow; r++) {
+    for (let c = bounds.minCol; c <= bounds.maxCol; c++) {
       const key = `${r},${c}`;
-      const boardTile = boardState.get(key);
-      if (boardTile) {
-        const tileElement = buildTileElement(boardTile);
-        boardGrid.appendChild(tileElement);
+      const tile = state.boardState.get(key);
+      if (tile) {
+        const tileElement = buildTileElement(tile);
+        grid.appendChild(tileElement);
         tileElements.set(key, tileElement);
       } else {
         const empty = document.createElement("div");
         empty.className = "empty-cell";
-        boardGrid.appendChild(empty);
+        grid.appendChild(empty);
       }
     }
   }
-  boardElement.appendChild(boardGrid);
-  boardGrid.dataset.minRow = minRow;
-  boardGrid.dataset.minCol = minCol;
-  boardElement.dataset.minRow = minRow;
-  boardElement.dataset.minCol = minCol;
+  boardElement.innerHTML = "";
+  boardElement.appendChild(grid);
+  boardElement._grid = grid;
+  boardElement.dataset.minRow = bounds.minRow;
+  boardElement.dataset.minCol = bounds.minCol;
   boardElement.dataset.rows = rows;
   boardElement.dataset.cols = cols;
-  boardElement._grid = boardGrid;
   renderTokens(tileElements);
 }
 
@@ -258,76 +287,62 @@ function buildTileElement(boardTile) {
   tile.className = "board-tile";
   tile.dataset.row = boardTile.row;
   tile.dataset.col = boardTile.col;
-  tile.dataset.tile = boardTile.base.tile_number;
+  tile.dataset.tile = tileState.tile_number;
   tile.dataset.orientation = boardTile.orientation;
   const segments = document.createElement("div");
   segments.className = "segments";
-
-  const cellPositions = [
-    { key: "top", gridArea: 2 },
-    { key: "left", gridArea: 4 },
-    { key: "middle", gridArea: 5 },
-    { key: "right", gridArea: 6 },
-    { key: "bottom", gridArea: 8 }
-  ];
-
-  const slotMap = {
-    0: "",
-    1: "",
-    2: "",
-    3: "",
-    4: "",
-    5: "",
-    6: "",
-    7: "",
-    8: ""
-  };
-
-  const typeClass = (type) => {
-    if (type === "S") return "soft";
-    if (type === "H") return "hard";
-    if (type === "N") return "neutral";
-    return "";
-  };
-
-  cellPositions.forEach((pos) => {
-    const seg = document.createElement("div");
-    seg.className = "segment";
-    const type = tileState[pos.key];
-    if (type) {
-      seg.classList.add(typeClass(type));
-      if (tileState.tile_number === "3-4" && pos.key === "middle") {
-        seg.classList.add("finish");
-        seg.textContent = "Finish";
-      }
-    }
-    slotMap[pos.gridArea] = seg;
+  const cells = new Array(9).fill(null).map(() => {
+    const div = document.createElement("div");
+    div.className = "segment";
+    return div;
   });
-
-  Object.keys(slotMap).forEach((gridIdx) => {
-    let seg = slotMap[gridIdx];
-    if (!seg) {
-      seg = document.createElement("div");
-      seg.className = "segment";
+  const applyType = (space, index) => {
+    const seg = cells[index];
+    const type = tileState[space];
+    if (type === "S") seg.classList.add("soft");
+    if (type === "N") seg.classList.add("neutral");
+    if (type === "H") seg.classList.add("hard");
+    if (tileState.tile_number === "3-4" && space === "middle") {
+      seg.classList.add("finish");
+      seg.textContent = "Finish";
     }
-    segments.appendChild(seg);
-  });
-
+  };
+  applyType("top", 1);
+  applyType("left", 3);
+  applyType("middle", 4);
+  applyType("right", 5);
+  applyType("bottom", 7);
+  cells.forEach((cell) => segments.appendChild(cell));
   tile.appendChild(segments);
   const label = document.createElement("div");
   label.className = "tile-number";
   label.textContent = tileState.tile_number;
   tile.appendChild(label);
 
-  tile.addEventListener("click", () => {
-    onTileClicked(boardTile.row, boardTile.col);
-  });
+  if (boardTile._animateFrom) {
+    const dx = (boardTile._animateFrom.col - boardTile.col) * 78;
+    const dy = (boardTile._animateFrom.row - boardTile.row) * 78;
+    tile.style.setProperty("--tx", `${dx}px`);
+    tile.style.setProperty("--ty", `${dy}px`);
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        tile.style.setProperty("--tx", "0px");
+        tile.style.setProperty("--ty", "0px");
+      });
+    });
+    delete boardTile._animateFrom;
+  } else {
+    tile.style.setProperty("--tx", "0px");
+    tile.style.setProperty("--ty", "0px");
+  }
+  tile.style.setProperty("--angle", `${boardTile.orientation * 90}deg`);
+  tile.addEventListener("click", () => handleTileClick(boardTile.row, boardTile.col));
   return tile;
 }
 
 function renderTokens(tileElements = new Map()) {
-  players.forEach((player, idx) => {
-    const token = playerTokens.get(player.id);
+  state.players.forEach((player, idx) => {
+    const token = state.playerTokens.get(player.id);
     if (!token) return;
     if (!player.pos) {
       token.style.display = "none";
@@ -338,11 +353,11 @@ function renderTokens(tileElements = new Map()) {
     const tileElement = tileElements.get(key) || findTileElement(key);
     if (tileElement) {
       tileElement.appendChild(token);
-      const space = SPACE_POSITIONS[player.pos.space];
-      token.style.left = `${space.x * 100}%`;
-      token.style.top = `${space.y * 100}%`;
+      const spacePos = SPACE_POSITIONS[player.pos.space];
+      token.style.left = `${spacePos.x * 100}%`;
+      token.style.top = `${spacePos.y * 100}%`;
     }
-    token.classList.toggle("active", idx === currentPlayerIndex);
+    token.classList.toggle("active", idx === state.currentPlayerIndex);
   });
 }
 
@@ -358,7 +373,7 @@ function getBoardBounds(extraCells = []) {
   let maxRow = -Infinity;
   let minCol = Infinity;
   let maxCol = -Infinity;
-  boardState.forEach((tile) => {
+  state.boardState.forEach((tile) => {
     minRow = Math.min(minRow, tile.row);
     maxRow = Math.max(maxRow, tile.row);
     minCol = Math.min(minCol, tile.col);
@@ -371,42 +386,38 @@ function getBoardBounds(extraCells = []) {
     maxCol = Math.max(maxCol, cell.col);
   });
   if (!isFinite(minRow)) {
-    minRow = 0;
-    maxRow = 0;
-    minCol = 0;
-    maxCol = 0;
+    return { minRow: 0, maxRow: 0, minCol: 0, maxCol: 0 };
   }
   return { minRow, maxRow, minCol, maxCol };
 }
 
 function onRollDice() {
-  if (gamePhase !== PHASES.AWAITING_ROLL) return;
+  if (state.gamePhase !== PHASES.AWAITING_ROLL) return;
   const die1 = 1 + Math.floor(Math.random() * 6);
   const die2 = 1 + Math.floor(Math.random() * 6);
-  diceResult = { die1, die2 };
+  state.dice = { die1, die2 };
   displayDice(die1, die2);
   narrate(`${currentPlayer().name} rolled ${die1} + ${die2} = ${die1 + die2}.`);
-  gamePhase = PHASES.AWAITING_MOVE;
+  state.gamePhase = PHASES.AWAITING_MOVE;
   updateControls();
   handleMovementPhase();
 }
 
 function displayDice(d1, d2) {
-  const diceFaces = ["", "⚀", "⚁", "⚂", "⚃", "⚄", "⚅"];
-  const [span1, span2, sum] = diceDisplay.querySelectorAll("span");
-  span1.textContent = diceFaces[d1];
-  span2.textContent = diceFaces[d2];
-  sum.textContent = `= ${d1 + d2}`;
+  const faces = ["", "⚀", "⚁", "⚂", "⚃", "⚄", "⚅"];
+  const spans = diceDisplay.querySelectorAll("span");
+  spans[0].textContent = faces[d1];
+  spans[1].textContent = faces[d2];
+  spans[2].textContent = `= ${d1 + d2}`;
 }
 
 function handleMovementPhase() {
   const player = currentPlayer();
-  const total = diceResult.die1 + diceResult.die2;
-  const startPos = player.pos;
+  const total = state.dice.die1 + state.dice.die2;
   const paths = findAllPaths(player, total);
   if (paths.length === 0) {
     narrate(`${player.name} cannot move ${total} spaces.`);
-    endMovementPhase(null);
+    endMovementPhase(false);
     return;
   }
   if (player.isCPU) {
@@ -417,69 +428,63 @@ function handleMovementPhase() {
 }
 
 function findAllPaths(player, total) {
-  const targetSteps = player.pos ? total : Math.max(total - 1, 0);
-  if (targetSteps <= 0) {
-    return [];
-  }
-  const startNodes = player.pos
-    ? [player.pos]
-    : [{ row: 0, col: 0, space: "middle" }];
+  const start = player.pos || { row: 0, col: 0, space: "middle" };
+  const steps = player.pos ? total : Math.max(total - 1, 0);
+  if (steps <= 0) return [];
   const paths = [];
-  startNodes.forEach((start) => {
-    depthSearch(start, targetSteps, [start], new Set([posKey(start)]), paths);
-  });
+  const visited = new Set([posKey(start)]);
+  depthFirstSearch(start, steps, [start], visited, paths, player);
   return paths;
 }
 
-function depthSearch(node, stepsRemaining, path, visited, outPaths) {
+function depthFirstSearch(node, stepsRemaining, path, visited, paths, player) {
   if (stepsRemaining === 0) {
-    outPaths.push([...path]);
+    paths.push([...path]);
     return;
   }
-  const neighbors = getNeighbors(node);
+  const neighbors = getNeighbors(node, player);
   neighbors.forEach((neighbor) => {
     const key = posKey(neighbor);
     if (visited.has(key)) return;
-    const newVisited = new Set(visited);
-    newVisited.add(key);
+    visited.add(key);
     path.push(neighbor);
-    depthSearch(neighbor, stepsRemaining - 1, path, newVisited, outPaths);
+    depthFirstSearch(neighbor, stepsRemaining - 1, path, visited, paths, player);
     path.pop();
+    visited.delete(key);
   });
 }
 
-function getNeighbors(position) {
-  const tileKey = `${position.row},${position.col}`;
-  const boardTile = boardState.get(tileKey);
+function getNeighbors(position, player) {
+  const key = `${position.row},${position.col}`;
+  const boardTile = state.boardState.get(key);
   if (!boardTile) return [];
   const tileState = getTileState(boardTile);
-  const connectionTargets = tileState.connections[position.space] || [];
+  const connections = tileState.connections[position.space] || [];
   const results = [];
-  connectionTargets.forEach((target) => {
-    if (target === "middle") {
+  connections.forEach((target) => {
+    if (target === "middle" || SIDES.includes(target)) {
       results.push({ row: position.row, col: position.col, space: target });
-    } else if (SIDES.includes(target)) {
-      const neighbor = getNeighborTile(position.row, position.col, target);
-      if (!neighbor) return;
-      const neighborState = getTileState(neighbor);
-      const opposite = SIDES[(SIDES.indexOf(target) + 2) % 4];
-      if (!neighborState[opposite]) return;
-      const neighborConnections = neighborState.connections[opposite] || [];
-      if (!neighborConnections.includes("middle")) {
-        results.push({ row: neighbor.row, col: neighbor.col, space: opposite });
-      } else {
-        results.push({ row: neighbor.row, col: neighbor.col, space: "middle" });
-      }
     }
+  });
+  SIDES.forEach((side) => {
+    if (!connections.includes(side)) return;
+    const [dr, dc] = sideDelta(side);
+    const neighborTile = state.boardState.get(`${position.row + dr},${position.col + dc}`);
+    if (!neighborTile) return;
+    const neighborState = getTileState(neighborTile);
+    const opposite = oppositeSide(side);
+    if (!neighborState[opposite]) return;
+    results.push({ row: position.row + dr, col: position.col + dc, space: opposite });
   });
   return results;
 }
 
-function getNeighborTile(row, col, side) {
-  const offsets = { top: [-1, 0], right: [0, 1], bottom: [1, 0], left: [0, -1] };
-  const delta = offsets[side];
-  const key = `${row + delta[0]},${col + delta[1]}`;
-  return boardState.get(key);
+function sideDelta(side) {
+  if (side === "top") return [-1, 0];
+  if (side === "bottom") return [1, 0];
+  if (side === "left") return [0, -1];
+  if (side === "right") return [0, 1];
+  return [0, 0];
 }
 
 function posKey(pos) {
@@ -487,236 +492,707 @@ function posKey(pos) {
 }
 
 function enablePathSelection(paths) {
-  const overlays = document.createElement("div");
-  overlays.className = "bump-overlay";
-  overlays.style.gridTemplateRows = boardElement._grid.style.gridTemplateRows;
-  overlays.style.gridTemplateColumns = boardElement._grid.style.gridTemplateColumns;
-  placementLayer.innerHTML = "";
-  placementLayer.appendChild(overlays);
-  placementLayer.style.pointerEvents = "none";
-  // highlight endpoints
-  const endPositions = new Map();
+  const endpoints = new Map();
   paths.forEach((path) => {
     const end = path[path.length - 1];
-    const key = `${end.row},${end.col},${end.space}`;
-    if (!endPositions.has(key)) {
-      endPositions.set(key, []);
+    const key = posKey(end);
+    if (!endpoints.has(key)) {
+      endpoints.set(key, []);
     }
-    endPositions.get(key).push(path);
+    endpoints.get(key).push(path);
   });
-  endPositions.forEach((pathOptions, key) => {
-    const [row, col, space] = key.split(",");
-    const index = getGridIndex(Number(row), Number(col));
-    if (index < 0) return;
-    const target = document.createElement("button");
-    target.className = "bump-target";
-    target.textContent = `${space}`;
-    target.addEventListener("click", () => {
-      placementLayer.innerHTML = "";
-      executeMovement(pathOptions[0]);
-    });
-    overlays.appendChild(target);
-  });
+  createOverlay(endpoints, (path) => executeMovement(path));
 }
 
-function getGridIndex(row, col) {
-  const minRow = Number(boardElement.dataset.minRow || 0);
-  const minCol = Number(boardElement.dataset.minCol || 0);
-  const cols = Number(boardElement.dataset.cols || 0);
-  const r = row - minRow;
-  const c = col - minCol;
-  if (r < 0 || c < 0 || r >= Number(boardElement.dataset.rows) || c >= cols) return -1;
-  return r * cols + c;
-}
-
-function executeMovement(path) {
-  const player = currentPlayer();
-  const start = player.pos;
-  const end = path[path.length - 1];
-  player.pos = { ...end };
-  renderBoard();
-  renderTokens();
-  narrate(`${player.name} moved to (${end.row}, ${end.col}) ${end.space}.`);
+function createOverlay(endpointMap, callback) {
   placementLayer.innerHTML = "";
-  handleLandingEffects(player, end);
+  const bounds = state.lastBounds;
+  const rows = bounds.maxRow - bounds.minRow + 1;
+  const cols = bounds.maxCol - bounds.minCol + 1;
+  const grid = document.createElement("div");
+  grid.className = "bump-grid";
+  grid.style.display = "grid";
+  grid.style.gridTemplateRows = `repeat(${rows}, 72px)`;
+  grid.style.gridTemplateColumns = `repeat(${cols}, 72px)`;
+  grid.style.gap = "6px";
+  grid.style.transform = `scale(${state.boardScale})`;
+  grid.style.transformOrigin = "center center";
+  grid.style.margin = "0 auto";
+  for (let r = bounds.minRow; r <= bounds.maxRow; r++) {
+    for (let c = bounds.minCol; c <= bounds.maxCol; c++) {
+      const cell = document.createElement("div");
+      cell.className = "overlay-cell";
+      cell.style.pointerEvents = "none";
+      if (endpointMap) {
+        const match = Array.from(endpointMap.keys()).find((pos) => {
+          const [er, ec] = pos.split(",");
+          return Number(er) === r && Number(ec) === c;
+        });
+        if (match) {
+          const button = document.createElement("button");
+          button.className = "bump-target";
+          const [, , space] = match.split(",");
+          button.textContent = "";
+          button.dataset.space = space;
+          button.title = space;
+          button.setAttribute("aria-label", space);
+          const pos = SPACE_POSITIONS[space] || SPACE_POSITIONS.middle;
+          button.style.position = "absolute";
+          button.style.left = `${pos.x * 100}%`;
+          button.style.top = `${pos.y * 100}%`;
+          button.style.transform = "translate(-50%, -50%)";
+          button.style.width = "36px";
+          button.style.height = "36px";
+          button.addEventListener("click", () => {
+            placementLayer.innerHTML = "";
+            callback(endpointMap.get(match)[0]);
+          });
+          button.style.pointerEvents = "auto";
+          cell.appendChild(button);
+        }
+      }
+      grid.appendChild(cell);
+    }
+  }
+  placementLayer.appendChild(grid);
+  placementLayer.style.pointerEvents = "auto";
 }
 
-function handleLandingEffects(player, endPosition) {
-  const tileState = getTileState(boardState.get(`${endPosition.row},${endPosition.col}`));
-  const spaceType = tileState[endPosition.space];
-  const occupant = getPlayerAt(endPosition, player.id);
-  const finishReached = endPosition.row === finishRow && endPosition.col === finishCol && endPosition.space === "middle";
-  if (finishReached) {
+async function executeMovement(path) {
+  placementLayer.innerHTML = "";
+  placementLayer.style.pointerEvents = "none";
+  const player = currentPlayer();
+  for (let i = 1; i < path.length; i++) {
+    await moveTokenTo(player, path[i]);
+    await wait(150);
+  }
+  const destination = path[path.length - 1];
+  const occupant = state.players.find((p) => p !== player && p.pos && posKey(p.pos) === posKey(destination));
+  player.pos = { ...destination };
+  renderTokens();
+  if (destination.row === state.finishRow && destination.col === state.finishCol && destination.space === "middle") {
     endGame(player);
     return;
   }
   if (occupant) {
-    triggerBump(player, occupant, endPosition);
+    narrate(`${player.name} bumped ${occupant.name}!`);
+    startBumpSequence(player, occupant);
     return;
   }
-  if (spaceType === "S") {
-    narrate(`${player.name} landed on Soft water and gains another turn!`);
+  applyLandingEffect(player, destination);
+}
+
+async function moveTokenTo(player, target) {
+  player.pos = { ...target };
+  renderTokens();
+  await wait(200);
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function applyLandingEffect(player, destination) {
+  const tile = state.boardState.get(`${destination.row},${destination.col}`);
+  if (!tile) {
+    endMovementPhase(false);
+    return;
+  }
+  const tileState = getTileState(tile);
+  const type = tileState[destination.space];
+  if (type === "S") {
+    narrate(`${player.name} landed on Soft water and gets another turn after shifting.`);
     endMovementPhase(true);
-  } else if (spaceType === "H") {
+  } else if (type === "H") {
     player.missNextTurn = true;
-    narrate(`${player.name} landed on Hard water and will miss their next turn.`);
+    narrate(`${player.name} landed on Hard water and will miss next turn.`);
     endMovementPhase(false);
   } else {
     endMovementPhase(false);
   }
 }
 
-function getPlayerAt(position, excludeId) {
-  return players.find((p) => p.id !== excludeId && p.pos && p.pos.row === position.row && p.pos.col === position.col && p.pos.space === position.space);
+function endMovementPhase(extraTurn) {
+  state.gamePhase = PHASES.AWAITING_SHIFT;
+  state.pendingShift = { extraTurn };
+  state.extraTurnQueued = extraTurn;
+  updateControls();
+  beginShiftPhase();
 }
 
-function triggerBump(active, victim, position) {
-  narrate(`${active.name} bumped ${victim.name}! Choose a neutral space for relocation.`);
-  gamePhase = PHASES.BUMP_RELOCATE;
-  bumpContext = { activeId: active.id, victimId: victim.id };
-  if (victim.isCPU) {
-    chooseCpuBump(active, victim);
-  } else if (active.isCPU) {
-    chooseCpuBump(active, victim);
+function beginShiftPhase() {
+  const player = currentPlayer();
+  const { die1, die2 } = state.dice;
+  const targetNumbers = new Set([`${die1}-${die2}`, `${die2}-${die1}`]);
+  const availableTiles = Array.from(state.boardState.values()).filter((tile) => targetNumbers.has(tile.base.tile_number));
+  const legalTiles = availableTiles.filter((tile) => {
+    const options = computePlacementOptions(tile, { excludeCurrent: true });
+    return options.some((option) => option.rotations.length > 0);
+  });
+  if (legalTiles.length === 0) {
+    narrate(`${player.name} cannot shift any tiles.`);
+    endShiftPhase(true);
+    return;
+  }
+  if (player.isCPU) {
+    cpuHandleShift(legalTiles);
   } else {
-    highlightNeutralSpaces((target) => {
-      relocatePlayer(victim, target);
-      allowOptionalRotation(victim);
-    });
+    narrate(`${player.name} may shift tile ${Array.from(targetNumbers).join(" or ")}.`);
+    highlightShiftableTiles(legalTiles.map((t) => `${t.row},${t.col}`));
   }
 }
 
-function highlightNeutralSpaces(callback) {
-  placementLayer.innerHTML = "";
-  const overlay = document.createElement("div");
-  overlay.className = "bump-overlay";
-  overlay.style.gridTemplateRows = boardElement._grid.style.gridTemplateRows;
-  overlay.style.gridTemplateColumns = boardElement._grid.style.gridTemplateColumns;
-  placementLayer.appendChild(overlay);
-  boardState.forEach((boardTile, key) => {
-    const tileState = getTileState(boardTile);
-    const tileElement = findTileElement(key);
-    const neutralSpaces = SIDES.concat("middle").filter((space) => tileState[space] === "N");
-    neutralSpaces.forEach((space) => {
-      const button = document.createElement("button");
-      button.className = "bump-target";
-      button.textContent = `${space}`;
-      button.addEventListener("click", () => {
-        placementLayer.innerHTML = "";
-        callback({ row: boardTile.row, col: boardTile.col, space });
-      });
-      overlay.appendChild(button);
-      if (tileElement) {
-        tileElement.appendChild(button);
-      }
-    });
+function highlightShiftableTiles(keys) {
+  const grid = boardElement._grid;
+  if (!grid) return;
+  keys.forEach((key) => {
+    const tile = findTileElement(key);
+    if (tile) {
+      tile.classList.add("shift-highlight");
+      tile.addEventListener("click", handleShiftTileSelection, { once: true });
+    }
   });
 }
 
-function relocatePlayer(player, position) {
-  player.pos = { ...position };
+function clearShiftHighlights() {
+  const grid = boardElement._grid;
+  if (!grid) return;
+  grid.querySelectorAll(".shift-highlight").forEach((tile) => {
+    tile.classList.remove("shift-highlight");
+  });
+}
+
+function handleShiftTileSelection(event) {
+  const tileElement = event.currentTarget;
+  clearShiftHighlights();
+  const row = Number(tileElement.dataset.row);
+  const col = Number(tileElement.dataset.col);
+  startShift(row, col);
+}
+
+function handleTileClick(row, col) {
+  if (state.gamePhase === PHASES.AWAITING_SHIFT && state.pendingShift && state.pendingShift.tile && !currentPlayer().isCPU) {
+    if (state.pendingShift.placed && row === state.pendingShift.tile.row && col === state.pendingShift.tile.col) {
+      rotatePlacedTile();
+    } else if (!state.pendingShift.pickedUp) {
+      startShift(row, col);
+    } else {
+      placeTileAt(row, col);
+    }
+  }
+}
+
+function startShift(row, col) {
+  clearShiftHighlights();
+  const tile = state.boardState.get(`${row},${col}`);
+  if (!tile) return;
+  const allowed = new Set([`${state.dice.die1}-${state.dice.die2}`, `${state.dice.die2}-${state.dice.die1}`]);
+  if (!allowed.has(tile.base.tile_number)) return;
+  state.pendingShift = {
+    tile,
+    originRow: row,
+    originCol: col,
+    pickedUp: true,
+    placed: false,
+    extraTurn: state.pendingShift ? state.pendingShift.extraTurn : false,
+    rotationOptions: [],
+    removedPlayers: getPlayersOnTile(row, col)
+  };
+  narrate(`${currentPlayer().name} picked up tile ${tile.base.tile_number}.`);
+  state.boardState.delete(`${row},${col}`);
+  state.pendingShift.removedPlayers.forEach((p) => {
+    p.pos = null;
+  });
   renderBoard();
   renderTokens();
-  narrate(`${player.name} relocated to (${position.row}, ${position.col}) ${position.space}.`);
+  showPlacementOptions();
 }
 
-function allowOptionalRotation(targetPlayer) {
-  const tileKey = `${targetPlayer.pos.row},${targetPlayer.pos.col}`;
-  const boardTile = boardState.get(tileKey);
-  if (!boardTile) {
-    endMovementPhase(false);
+function getPlayersOnTile(row, col) {
+  return state.players.filter((p) => p.pos && p.pos.row === row && p.pos.col === col);
+}
+
+function showPlacementOptions() {
+  if (!state.pendingShift || !state.pendingShift.tile) return;
+  const options = computePlacementOptions(state.pendingShift.tile);
+  placementLayer.innerHTML = "";
+  renderBoard(options.map((o) => ({ row: o.row, col: o.col })));
+  const bounds = state.lastBounds;
+  const rows = bounds.maxRow - bounds.minRow + 1;
+  const cols = bounds.maxCol - bounds.minCol + 1;
+  const grid = document.createElement("div");
+  grid.className = "placement-grid";
+  grid.style.display = "grid";
+  grid.style.gridTemplateRows = `repeat(${rows}, 72px)`;
+  grid.style.gridTemplateColumns = `repeat(${cols}, 72px)`;
+  grid.style.gap = "6px";
+  grid.style.transform = `scale(${state.boardScale})`;
+  grid.style.transformOrigin = "center center";
+  grid.style.margin = "0 auto";
+  for (let r = bounds.minRow; r <= bounds.maxRow; r++) {
+    for (let c = bounds.minCol; c <= bounds.maxCol; c++) {
+      const option = options.find((o) => o.row === r && o.col === c);
+      const cell = document.createElement("div");
+      if (!option || option.rotations.length === 0) {
+        cell.className = "overlay-cell";
+        cell.style.pointerEvents = "none";
+      } else {
+        cell.className = "placement-cell";
+        cell.addEventListener("click", () => placeTileAt(option.row, option.col, option.rotations));
+      }
+      grid.appendChild(cell);
+    }
+  }
+  placementLayer.appendChild(grid);
+  placementLayer.style.pointerEvents = "auto";
+}
+
+function computePlacementOptions(tile, { excludeCurrent = false } = {}) {
+  const options = [];
+  const seen = new Set();
+  const currentKey = `${tile.row},${tile.col}`;
+  let removed = null;
+  if (excludeCurrent && state.boardState.get(currentKey) === tile) {
+    removed = tile;
+    state.boardState.delete(currentKey);
+  }
+  state.boardState.forEach((other) => {
+    [[-1, 0], [1, 0], [0, -1], [0, 1]].forEach(([dr, dc]) => {
+      const row = other.row + dr;
+      const col = other.col + dc;
+      const key = `${row},${col}`;
+      if (state.boardState.has(key) || seen.has(key)) return;
+      seen.add(key);
+      const rotations = getValidRotations(tile.base, row, col);
+      options.push({ row, col, rotations });
+    });
+  });
+  if (removed) {
+    state.boardState.set(currentKey, removed);
+  }
+  return options;
+}
+
+function getValidRotations(baseTile, row, col) {
+  const rotations = [];
+  for (let orientation = 0; orientation < 4; orientation++) {
+    const rotated = getTileState({ base: baseTile, orientation, row, col });
+    if (isPlacementValid(rotated)) {
+      rotations.push(orientation);
+    }
+  }
+  return rotations;
+}
+
+function isPlacementValid(tileState) {
+  let hasNeighbor = false;
+  let hasConnection = false;
+  for (const side of SIDES) {
+    const [dr, dc] = sideDelta(side);
+    const neighbor = state.boardState.get(`${tileState.row + dr},${tileState.col + dc}`);
+    if (!neighbor) continue;
+    hasNeighbor = true;
+    const neighborState = getTileState(neighbor);
+    const opposite = oppositeSide(side);
+    if (tileState[side] && neighborState[opposite]) {
+      hasConnection = true;
+    }
+  }
+  return hasNeighbor && hasConnection;
+}
+
+function placeTileAt(row, col, rotationOptions = null) {
+  if (!state.pendingShift || !state.pendingShift.tile) return;
+  const rotations = rotationOptions || getValidRotations(state.pendingShift.tile.base, row, col);
+  if (rotations.length === 0) {
+    narrate("No valid orientation there.");
     return;
   }
-  narrate(`You may rotate tile ${boardTile.base.tile_number} that ${targetPlayer.name} landed on.`);
-  const tileElement = findTileElement(tileKey);
-  const rotationHandler = () => {
-    rotateBoardTile(boardTile, 1);
-    updateTokenAfterRotation(targetPlayer, 1);
+  const orientation = rotations[0];
+  const tile = state.pendingShift.tile;
+  tile.row = row;
+  tile.col = col;
+  tile._animateFrom = { row: state.pendingShift.originRow, col: state.pendingShift.originCol };
+  tile.orientation = orientation;
+  state.boardState.set(`${row},${col}`, tile);
+  if (tile.base.tile_number === "3-4") {
+    state.finishRow = row;
+    state.finishCol = col;
+  }
+  state.pendingShift.rotationOptions = rotations;
+  state.pendingShift.pickedUp = true;
+  state.pendingShift.placed = true;
+  placementLayer.innerHTML = "";
+  renderBoard();
+  renderTokens();
+  state.awaitingConfirm = true;
+  updateControls();
+  if (rotations.length > 1) {
+    narrate("Click the placed tile to cycle orientations, then confirm placement.");
+  } else {
+    narrate("Only one orientation fits here. Confirm placement when ready.");
+  }
+}
+
+function rotatePlacedTile() {
+  if (!state.pendingShift || !state.pendingShift.placed) return;
+  const rotations = state.pendingShift.rotationOptions;
+  const tile = state.pendingShift.tile;
+  if (rotations.length <= 1) {
+    const element = findTileElement(`${tile.row},${tile.col}`);
+    if (element) {
+      element.classList.add("rotating");
+      element.style.setProperty("--angle", `${tile.orientation * 90 + 360}deg`);
+      setTimeout(() => {
+        element.classList.remove("rotating");
+        element.style.setProperty("--angle", `${tile.orientation * 90}deg`);
+      }, 400);
+    }
+    return;
+  }
+  const idx = rotations.indexOf(tile.orientation);
+  const next = rotations[(idx + 1) % rotations.length];
+  const previous = tile.orientation;
+  tile.orientation = next;
+  const element = findTileElement(`${tile.row},${tile.col}`);
+  if (element) {
+    element.classList.add("rotating");
+    element.style.setProperty("--angle", `${previous * 90}deg`);
+    requestAnimationFrame(() => {
+      element.style.setProperty("--angle", `${next * 90}deg`);
+      setTimeout(() => element.classList.remove("rotating"), 350);
+    });
+  }
+  adjustTokensForRotation(tile, previous, next);
+}
+
+function adjustTokensForRotation(tile, fromOrientation, toOrientation) {
+  const steps = ((toOrientation - fromOrientation + 4) % 4);
+  if (steps === 0) return;
+  const affected = state.players.filter((p) => p.pos && p.pos.row === tile.row && p.pos.col === tile.col);
+  affected.forEach((player) => {
+    if (player.pos.space === "middle") return;
+    const idx = SIDES.indexOf(player.pos.space);
+    const newSpace = SIDES[(idx + steps) % 4];
+    player.pos = { row: tile.row, col: tile.col, space: newSpace };
+  });
+  renderTokens();
+}
+
+function confirmShiftPlacement() {
+  if (!state.pendingShift || !state.pendingShift.placed) return;
+  state.awaitingConfirm = false;
+  updateControls();
+  placementLayer.innerHTML = "";
+  if (state.pendingShift.removedPlayers && state.pendingShift.removedPlayers.length) {
+    relocateRemovedPlayers([...state.pendingShift.removedPlayers]);
+  } else {
+    endShiftPhase(true);
+  }
+}
+
+function relocateRemovedPlayers(queue) {
+  if (queue.length === 0) {
+    endShiftPhase(true);
+    return;
+  }
+  const victim = queue.shift();
+  const neutrals = collectNeutralSpaces();
+  if (neutrals.length === 0) {
+    victim.pos = null;
+    relocateRemovedPlayers(queue);
+    return;
+  }
+  if (currentPlayer().isCPU) {
+    const target = chooseCpuNeutral(victim, neutrals);
+    narrate(`CPU relocates ${victim.name} to (${target.row},${target.col}) ${target.space}.`, 400);
+    victim.pos = target;
+    renderTokens();
+    offerRotationAfterBump(victim, () => relocateRemovedPlayers(queue));
+  } else {
+    narrate(`Select a neutral space to relocate ${victim.name}.`);
+    highlightNeutralSpaces(neutrals, (choice) => {
+      victim.pos = choice;
+      renderTokens();
+      offerRotationAfterBump(victim, () => relocateRemovedPlayers(queue));
+    });
+  }
+}
+
+function collectNeutralSpaces() {
+  const spaces = [];
+  state.boardState.forEach((tile) => {
+    const tileState = getTileState(tile);
+    ["top", "right", "bottom", "left", "middle"].forEach((space) => {
+      if (tileState[space] === "N") {
+        spaces.push({ row: tile.row, col: tile.col, space });
+      }
+    });
+  });
+  return spaces;
+}
+
+function highlightNeutralSpaces(neutrals, callback) {
+  placementLayer.innerHTML = "";
+  const bounds = state.lastBounds;
+  const rows = bounds.maxRow - bounds.minRow + 1;
+  const cols = bounds.maxCol - bounds.minCol + 1;
+  const grid = document.createElement("div");
+  grid.className = "bump-grid";
+  grid.style.display = "grid";
+  grid.style.gridTemplateRows = `repeat(${rows}, 72px)`;
+  grid.style.gridTemplateColumns = `repeat(${cols}, 72px)`;
+  grid.style.gap = "6px";
+  grid.style.transform = `scale(${state.boardScale})`;
+  grid.style.transformOrigin = "center center";
+  grid.style.margin = "0 auto";
+  for (let r = bounds.minRow; r <= bounds.maxRow; r++) {
+    for (let c = bounds.minCol; c <= bounds.maxCol; c++) {
+      const cell = document.createElement("div");
+      cell.className = "overlay-cell";
+      cell.style.pointerEvents = "none";
+      const choices = neutrals.filter((p) => p.row === r && p.col === c);
+      if (choices.length) {
+        choices.forEach((choice) => {
+          const button = document.createElement("button");
+          button.className = "bump-target";
+          button.textContent = "";
+          button.dataset.space = choice.space;
+          button.title = choice.space;
+          button.setAttribute("aria-label", choice.space);
+          const pos = SPACE_POSITIONS[choice.space] || SPACE_POSITIONS.middle;
+          button.style.position = "absolute";
+          button.style.left = `${pos.x * 100}%`;
+          button.style.top = `${pos.y * 100}%`;
+          button.style.transform = "translate(-50%, -50%)";
+          button.style.width = "36px";
+          button.style.height = "36px";
+          button.addEventListener("click", () => {
+            placementLayer.innerHTML = "";
+            callback({ ...choice });
+          });
+          button.style.pointerEvents = "auto";
+          cell.appendChild(button);
+        });
+      }
+      grid.appendChild(cell);
+    }
+  }
+  placementLayer.appendChild(grid);
+  placementLayer.style.pointerEvents = "auto";
+}
+
+function offerRotationAfterBump(victim, onComplete) {
+  placementLayer.innerHTML = "";
+  placementLayer.style.pointerEvents = "none";
+  if (!victim.pos) {
+    onComplete();
+    return;
+  }
+  const tile = state.boardState.get(`${victim.pos.row},${victim.pos.col}`);
+  if (!tile) {
+    onComplete();
+    return;
+  }
+  const actor = currentPlayer();
+  if (actor.isCPU) {
+    rotateTileWithDecision(tile, actor);
+    onComplete();
+  } else {
+    const info = document.createElement("div");
+    info.className = "status-inline";
+    info.textContent = "Optional: click the relocated tile to rotate it, or press Skip.";
+    announcerLog.appendChild(info);
+    announcerLog.scrollTop = announcerLog.scrollHeight;
+    const skip = document.createElement("button");
+    skip.textContent = "Skip Rotation";
+    const controls = document.querySelector(".controls .control-buttons");
+    controls.appendChild(skip);
+    let active = true;
+    const attach = () => {
+      if (!active) return;
+      const el = findTileElement(`${tile.row},${tile.col}`);
+      if (!el) return;
+      el.addEventListener(
+        "click",
+        () => {
+          if (!active) return;
+          rotateTileInstant(tile, (tile.orientation + 1) % 4);
+          attach();
+        },
+        { once: true }
+      );
+    };
+    attach();
+    skip.addEventListener("click", () => {
+      active = false;
+      skip.remove();
+      info.remove();
+      placementLayer.innerHTML = "";
+      placementLayer.style.pointerEvents = "none";
+      onComplete();
+    });
+    setTimeout(() => {
+      if (active) {
+        skip.click();
+      }
+    }, 4000);
+  }
+}
+
+function rotateTileWithDecision(tile, actor) {
+  const rotations = [0, 1, 2, 3].map((step) => (tile.orientation + step) % 4);
+  let best = tile.orientation;
+  let bestScore = -Infinity;
+  rotations.forEach((orientation) => {
+    const score = evaluateRotation(tile, orientation, actor);
+    if (score > bestScore) {
+      bestScore = score;
+      best = orientation;
+    }
+  });
+  if (best !== tile.orientation) {
+    const prev = tile.orientation;
+    tile.orientation = best;
+    adjustTokensForRotation(tile, prev, best);
     renderBoard();
     renderTokens();
-  };
-  tileElement?.addEventListener("click", rotationHandler, { once: true });
-  endMovementPhase(false);
+    narrate(`CPU rotates tile ${tile.base.tile_number}.`, 500);
+  }
 }
 
-function updateTokenAfterRotation(player, steps) {
-  if (!player.pos) return;
-  const order = ["top", "right", "bottom", "left"];
-  let index = order.indexOf(player.pos.space);
-  if (index === -1) return;
-  index = (index + steps) % 4;
-  player.pos.space = order[index];
+function evaluateRotation(tile, orientation, actor) {
+  const temp = tile.orientation;
+  tile.orientation = orientation;
+  const actorDist = shortestPathLength(actor);
+  tile.orientation = temp;
+  return actorDist === null ? -Infinity : -actorDist;
 }
 
-function endMovementPhase(repeatTurn) {
+function rotateTileInstant(tile, newOrientation) {
+  const previous = tile.orientation;
+  tile.orientation = newOrientation;
+  adjustTokensForRotation(tile, previous, newOrientation);
+  renderBoard();
+  renderTokens();
+}
+
+function endShiftPhase(skipAnnounce) {
+  const grantExtra = state.extraTurnQueued;
+  state.pendingShift = null;
+  state.extraTurnQueued = false;
   placementLayer.innerHTML = "";
-  gamePhase = PHASES.AWAITING_SHIFT;
-  awaitingConfirm = false;
-  pendingShift = null;
-  if (repeatTurn) {
-    narrate(`${currentPlayer().name} rolls again!`);
-  }
+  placementLayer.style.pointerEvents = "none";
+  state.awaitingConfirm = false;
   updateControls();
-  if (currentPlayer().isCPU) {
-    processCpuShift();
+  if (grantExtra) {
+    narrate(`${currentPlayer().name} takes an extra turn!`);
+    state.gamePhase = PHASES.AWAITING_ROLL;
+    highlightCurrentPlayer();
+    updateControls();
+    if (currentPlayer().isCPU) {
+      processCpuTurn();
+    }
+    return;
   }
-}
-
-function endShiftPhase(skipped) {
-  narrate(skipped ? `${currentPlayer().name} skipped the shift.` : `${currentPlayer().name} completed the shift.`);
   advanceTurn();
 }
 
 function advanceTurn() {
-  placementLayer.innerHTML = "";
-  awaitingConfirm = false;
-  pendingShift = null;
-  bumpContext = null;
-  let nextIndex = currentPlayerIndex;
+  let nextIndex = state.currentPlayerIndex;
+  let loops = 0;
   do {
-    nextIndex = (nextIndex + 1) % players.length;
-    if (!players[nextIndex].missNextTurn) break;
-    players[nextIndex].missNextTurn = false;
-    narrate(`${players[nextIndex].name} misses this turn.`);
-  } while (nextIndex !== currentPlayerIndex);
-  currentPlayerIndex = nextIndex;
-  gamePhase = PHASES.AWAITING_ROLL;
+    nextIndex = (nextIndex + 1) % state.players.length;
+    const candidate = state.players[nextIndex];
+    if (candidate.missNextTurn) {
+      candidate.missNextTurn = false;
+      narrate(`${candidate.name} misses this turn.`);
+      loops++;
+      continue;
+    }
+    break;
+  } while (loops < state.players.length);
+  state.currentPlayerIndex = nextIndex;
+  state.gamePhase = PHASES.AWAITING_ROLL;
   highlightCurrentPlayer();
   updateControls();
-  if (isCurrentPlayerCPU()) {
+  if (currentPlayer().isCPU) {
     processCpuTurn();
   }
 }
 
-function currentPlayer() {
-  return players[currentPlayerIndex];
+function startBumpSequence(active, victim) {
+  state.gamePhase = PHASES.BUMP_RELOCATE;
+  const neutrals = collectNeutralSpaces();
+  if (neutrals.length === 0) {
+    victim.pos = null;
+    state.gamePhase = PHASES.AWAITING_SHIFT;
+    endMovementPhase(false);
+    return;
+  }
+  if (active.isCPU) {
+    const target = chooseCpuNeutral(victim, neutrals);
+    narrate(`CPU relocates ${victim.name} to (${target.row},${target.col}) ${target.space}.`, 600).then(() => {
+      victim.pos = target;
+      renderTokens();
+      offerRotationAfterBump(victim, () => applyLandingEffect(active, active.pos));
+    });
+  } else {
+    narrate(`Select a neutral space to move ${victim.name}.`);
+    highlightNeutralSpaces(neutrals, (choice) => {
+      victim.pos = choice;
+      renderTokens();
+      offerRotationAfterBump(victim, () => applyLandingEffect(active, active.pos));
+    });
+  }
 }
 
-function isCurrentPlayerCPU() {
-  return currentPlayer().isCPU;
+function chooseCpuNeutral(victim, neutrals) {
+  let best = neutrals[0];
+  let bestScore = -Infinity;
+  neutrals.forEach((space) => {
+    const score = scoreNeutralPlacement(victim, space);
+    if (score > bestScore) {
+      bestScore = score;
+      best = space;
+    }
+  });
+  return { ...best };
+}
+
+function scoreNeutralPlacement(victim, space) {
+  const original = victim.pos;
+  victim.pos = space;
+  const distance = shortestPathLength(victim);
+  victim.pos = original;
+  return distance === null ? 999 : distance;
 }
 
 function highlightCurrentPlayer() {
-  players.forEach((player, idx) => {
-    const token = playerTokens.get(player.id);
+  state.players.forEach((player, idx) => {
+    const token = state.playerTokens.get(player.id);
     if (token) {
-      token.classList.toggle("active", idx === currentPlayerIndex);
+      token.classList.toggle("active", idx === state.currentPlayerIndex);
     }
   });
 }
 
 function updateControls() {
-  rollBtn.disabled = gamePhase !== PHASES.AWAITING_ROLL || isCurrentPlayerCPU();
-  confirmPlacementBtn.classList.toggle("hidden", !awaitingConfirm);
-  skipShiftBtn.classList.toggle("hidden", isCurrentPlayerCPU() || gamePhase !== PHASES.AWAITING_SHIFT);
+  rollBtn.disabled = state.gamePhase !== PHASES.AWAITING_ROLL || currentPlayer().isCPU;
+  confirmPlacementBtn.classList.toggle("hidden", !state.awaitingConfirm);
+  const humanShiftPhase = state.gamePhase === PHASES.AWAITING_SHIFT && !currentPlayer().isCPU;
+  skipShiftBtn.classList.toggle("hidden", !humanShiftPhase);
+  const canRotate = humanShiftPhase && state.pendingShift && state.pendingShift.placed;
+  rotatePlacementBtn.classList.toggle("hidden", !canRotate);
+  rotatePlacementBtn.disabled = !canRotate;
 }
 
-function clearAnnouncer() {
-  announcerLog.innerHTML = "";
+function currentPlayer() {
+  return state.players[state.currentPlayerIndex];
 }
 
 function narrate(message, delay = 0) {
-  announcerQueue = announcerQueue.then(
+  state.announcerQueue = state.announcerQueue.then(
     () =>
       new Promise((resolve) => {
         setTimeout(() => {
@@ -728,231 +1204,137 @@ function narrate(message, delay = 0) {
         }, delay);
       })
   );
-  return announcerQueue;
-}
-
-function onTileClicked(row, col) {
-  if (gamePhase === PHASES.AWAITING_SHIFT && currentPlayer().pos) {
-    if (!pendingShift) {
-      const tile = boardState.get(`${row},${col}`);
-      if (!tile) return;
-      pickupTile(tile);
-    } else if (pendingShift && pendingShift.tile) {
-      placeTileAt(row, col);
-    }
-  }
-}
-
-function pickupTile(tile) {
-  const key = `${tile.row},${tile.col}`;
-  if (!boardState.has(key)) return;
-  pendingShift = {
-    tile,
-    originRow: tile.row,
-    originCol: tile.col,
-    removedPlayers: getPlayersOnTile(tile.row, tile.col)
-  };
-  boardState.delete(key);
-  pendingShift.removedPlayers.forEach((player) => {
-    player.pos = null;
-  });
-  narrate(`${currentPlayer().name} picked up tile ${tile.base.tile_number}.`);
-  renderBoard();
-  renderTokens();
-  showPlacementOptions();
-}
-
-function getPlayersOnTile(row, col) {
-  return players.filter((p) => p.pos && p.pos.row === row && p.pos.col === col);
-}
-
-function showPlacementOptions() {
-  if (!pendingShift) return;
-  const options = computePlacementOptions(pendingShift.tile);
-  placementLayer.innerHTML = "";
-  const { minRow, maxRow, minCol, maxCol } = getBoardBounds(options);
-  renderBoard(options);
-  const rows = maxRow - minRow + 1;
-  const cols = maxCol - minCol + 1;
-  const overlay = document.createElement("div");
-  overlay.className = "board-grid";
-  overlay.style.gridTemplateRows = `repeat(${rows}, var(--tile-size))`;
-  overlay.style.gridTemplateColumns = `repeat(${cols}, var(--tile-size))`;
-  options.forEach((cell) => {
-    const cellDiv = document.createElement("div");
-    cellDiv.className = "placement-cell";
-    if (!cell.valid) cellDiv.classList.add("invalid");
-    if (cell.highlight) cellDiv.classList.add("highlight");
-    cellDiv.addEventListener("click", () => {
-      if (!cell.valid) return;
-      pendingShift.target = cell;
-      placeTileAt(cell.row, cell.col);
-    });
-    overlay.appendChild(cellDiv);
-  });
-  placementLayer.appendChild(overlay);
-  placementLayer.style.pointerEvents = "auto";
-}
-
-function computePlacementOptions(tile) {
-  const options = [];
-  const visited = new Set();
-  boardState.forEach((other) => {
-    const neighbors = [
-      { row: other.row - 1, col: other.col },
-      { row: other.row + 1, col: other.col },
-      { row: other.row, col: other.col - 1 },
-      { row: other.row, col: other.col + 1 }
-    ];
-    neighbors.forEach((n) => {
-      const key = `${n.row},${n.col}`;
-      if (boardState.has(key) || visited.has(key)) return;
-      visited.add(key);
-      const rotations = getValidRotations(tile, n.row, n.col);
-      options.push({ row: n.row, col: n.col, valid: rotations.length > 0, rotations });
-    });
-  });
-  return options;
-}
-
-function getValidRotations(tile, row, col) {
-  const valid = [];
-  for (let orientation = 0; orientation < 4; orientation++) {
-    const rotated = getTileState({ base: tile.base, orientation, row, col });
-    if (checkConnectivity(rotated)) {
-      valid.push(orientation);
-    }
-  }
-  return valid;
-}
-
-function checkConnectivity(tileState) {
-  const neighbors = [
-    { row: tileState.row - 1, col: tileState.col, side: "top" },
-    { row: tileState.row + 1, col: tileState.col, side: "bottom" },
-    { row: tileState.row, col: tileState.col - 1, side: "left" },
-    { row: tileState.row, col: tileState.col + 1, side: "right" }
-  ];
-  return neighbors.some((neighbor) => {
-    const boardTile = boardState.get(`${neighbor.row},${neighbor.col}`);
-    if (!boardTile) return false;
-    const neighborState = getTileState(boardTile);
-    const opposite = SIDES[(SIDES.indexOf(neighbor.side) + 2) % 4];
-    return tileState[neighbor.side] && neighborState[opposite];
-  });
-}
-
-function placeTileAt(row, col) {
-  if (!pendingShift) return;
-  const rotationOptions = getValidRotations(pendingShift.tile, row, col);
-  if (rotationOptions.length === 0) {
-    narrate("No valid orientation for that placement.");
-    return;
-  }
-  pendingShift.tile.row = row;
-  pendingShift.tile.col = col;
-  pendingShift.tile.orientation = rotationOptions[0];
-  boardState.set(`${row},${col}`, pendingShift.tile);
-  if (pendingShift.tile.base.tile_number === "3-4") {
-    finishRow = row;
-    finishCol = col;
-  }
-  narrate(`${currentPlayer().name} placed tile ${pendingShift.tile.base.tile_number} at (${row}, ${col}).`);
-  awaitingConfirm = true;
-  updateControls();
-  placementLayer.innerHTML = "";
-  renderBoard();
-  renderTokens();
-  confirmPlacementBtn.onclick = () => finalizePlacement(rotationOptions);
-}
-
-function finalizePlacement(rotations) {
-  confirmPlacementBtn.onclick = null;
-  awaitingConfirm = false;
-  updateControls();
-  if (pendingShift && pendingShift.removedPlayers) {
-    pendingShift.removedPlayers.forEach((player) => {
-      highlightNeutralSpaces((pos) => {
-        player.pos = pos;
-        renderBoard();
-        renderTokens();
-        endShiftPhase(false);
-      });
-    });
-  } else {
-    endShiftPhase(false);
-  }
-}
-
-function confirmShiftPlacement() {
-  if (!pendingShift) return;
-  finalizePlacement([pendingShift.tile.orientation]);
-}
-
-function rotateBoardTile(tile, steps) {
-  tile.orientation = (tile.orientation + steps) % 4;
+  return state.announcerQueue;
 }
 
 function endGame(player) {
-  gamePhase = PHASES.GAME_OVER;
-  narrate(`${player.name} reached the Finish!`);
+  state.gamePhase = PHASES.GAME_OVER;
+  narrate(`${player.name} reaches the Finish!`);
   victoryTitle.textContent = `${player.name} Wins!`;
-  victoryMessage.textContent = `Congratulations to ${player.name} for navigating the Culligan network first.`;
+  victoryMessage.textContent = `${player.name} connected the system first.`;
   victoryModal.classList.remove("hidden");
 }
 
 function processCpuTurn() {
-  if (gamePhase !== PHASES.AWAITING_ROLL) return;
   rollBtn.disabled = true;
-  setTimeout(() => {
-    onRollDice();
-  }, 1000);
+  wait(700).then(() => onRollDice());
 }
 
 function chooseCpuMovement(paths) {
-  paths.sort((a, b) => scoreMovementPath(b) - scoreMovementPath(a));
-  const best = paths[0];
-  narrate(`CPU evaluating ${paths.length} paths...`, 500).then(() => {
-    executeMovement(best);
-  });
+  const scored = paths.map((path) => ({ path, score: scoreCpuPath(path) }));
+  scored.sort((a, b) => b.score - a.score);
+  const best = scored[0].path;
+  narrate("CPU evaluates movement options...", 600).then(() => executeMovement(best));
 }
 
-function scoreMovementPath(path) {
+function scoreCpuPath(path) {
   const end = path[path.length - 1];
-  const distance = manhattanDistance(end, { row: finishRow, col: finishCol });
-  return -distance;
+  const distanceToFinish = Math.abs(end.row - state.finishRow) + Math.abs(end.col - state.finishCol);
+  let score = -distanceToFinish;
+  const tile = state.boardState.get(`${end.row},${end.col}`);
+  if (tile) {
+    const tileState = getTileState(tile);
+    const type = tileState[end.space];
+    if (type === "S") score += 2;
+    if (type === "H") score -= 2;
+  }
+  return score;
 }
 
-function chooseCpuBump(active, victim) {
-  const neutrals = [];
-  boardState.forEach((tile) => {
-    const state = getTileState(tile);
-    SIDES.concat("middle").forEach((space) => {
-      if (state[space] === "N") {
-        neutrals.push({ row: tile.row, col: tile.col, space });
+function shortestPathLength(player) {
+  if (!player.pos) return null;
+  const queue = [{ pos: player.pos, dist: 0 }];
+  const visited = new Set([posKey(player.pos)]);
+  while (queue.length) {
+    const { pos, dist } = queue.shift();
+    if (pos.row === state.finishRow && pos.col === state.finishCol && pos.space === "middle") {
+      return dist;
+    }
+    const neighbors = getNeighbors(pos, player);
+    neighbors.forEach((next) => {
+      const key = posKey(next);
+      if (!visited.has(key)) {
+        visited.add(key);
+        queue.push({ pos: next, dist: dist + 1 });
       }
     });
+  }
+  return null;
+}
+
+function cpuHandleShift(tiles) {
+  wait(600).then(() => {
+    const decision = evaluateCpuShift(tiles);
+    if (!decision) {
+      narrate("CPU skips the shift.");
+      endShiftPhase(true);
+      return;
+    }
+    const { tile, placement, orientation } = decision;
+    startShift(tile.row, tile.col);
+    wait(600).then(() => {
+      placeTileAt(placement.row, placement.col, [orientation]);
+      wait(600).then(() => confirmShiftPlacement());
+    });
   });
-  const target = neutrals[0];
-  relocatePlayer(victim, target);
-  endMovementPhase(false);
 }
 
-function processCpuShift() {
-  setTimeout(() => {
-    endShiftPhase(true);
-  }, 800);
+function evaluateCpuShift(tiles) {
+  let best = null;
+  let bestScore = -Infinity;
+  tiles.forEach((tile) => {
+    const placements = computePlacementOptions(tile, { excludeCurrent: true });
+    placements.forEach((option) => {
+      option.rotations.forEach((orientation) => {
+        const score = scoreShift(tile, option, orientation);
+        if (score > bestScore) {
+          bestScore = score;
+          best = { tile, placement: option, orientation };
+        }
+      });
+    });
+  });
+  if (bestScore <= 0) {
+    const reachable = shortestPathLength(currentPlayer());
+    if (reachable !== null) {
+      return null;
+    }
+  }
+  return best;
 }
 
-function manhattanDistance(a, b) {
-  return Math.abs(a.row - b.row) + Math.abs(a.col - b.col);
+function scoreShift(tile, option, orientation) {
+  const removed = state.boardState.get(`${option.row},${option.col}`);
+  const originalRow = tile.row;
+  const originalCol = tile.col;
+  state.boardState.delete(`${tile.row},${tile.col}`);
+  const copyTile = createBoardTile(tile.base, option.row, option.col, orientation);
+  state.boardState.set(`${option.row},${option.col}`, copyTile);
+  const cpuPlayer = currentPlayer();
+  const cpuDistance = shortestPathLength(cpuPlayer);
+  let humanPenalty = 0;
+  state.players.forEach((player) => {
+    if (player.isCPU) return;
+    const dist = shortestPathLength(player);
+    if (dist === null) {
+      humanPenalty += 5;
+    } else {
+      humanPenalty += dist;
+    }
+  });
+  state.boardState.delete(`${option.row},${option.col}`);
+  if (removed) {
+    state.boardState.set(`${option.row},${option.col}`, removed);
+  }
+  state.boardState.set(`${originalRow},${originalCol}`, tile);
+  if (cpuDistance === null) return -999;
+  return -cpuDistance - humanPenalty * 0.1;
 }
 
-function chooseCpuShift() {}
-
-function enableShiftSkip() {}
-
-function onCpuSkip() {}
-
-function allowRotationForPlacement(rotations) {}
-
+function oppositeSide(side) {
+  if (side === "top") return "bottom";
+  if (side === "bottom") return "top";
+  if (side === "left") return "right";
+  if (side === "right") return "left";
+  return side;
+}

--- a/style.css
+++ b/style.css
@@ -1,187 +1,131 @@
-:root {
-  --bg: #0f172a;
-  --panel: rgba(15, 23, 42, 0.72);
-  --text: #f8fafc;
-  --soft: #48bb78;
-  --neutral: #63b3ed;
-  --hard: #b794f4;
-  --tile: #1e293b;
-  --tile-border: rgba(148, 163, 184, 0.3);
-  --tile-number: #a0aec0;
-  --token-size: 2.2rem;
-  --tile-size: 80px;
-}
-
-* {
-  box-sizing: border-box;
-}
-
 body {
   margin: 0;
-  min-height: 100vh;
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  background: radial-gradient(circle at top, #1e293b, #0f172a 60%);
-  color: var(--text);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-button {
-  background: #1d4ed8;
-  border: none;
-  color: white;
-  padding: 0.65rem 1.25rem;
-  border-radius: 999px;
-  cursor: pointer;
-  font-size: 1rem;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-button:not(:disabled):hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 16px rgba(59, 130, 246, 0.4);
+  font-family: Arial, sans-serif;
+  background: #f4f4f4;
+  color: #222;
 }
 
 .hidden {
   display: none !important;
 }
 
-.game {
+main {
   display: flex;
-  gap: 2rem;
-  max-width: 1200px;
-  width: 100%;
-  padding: 2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+  padding: 16px;
 }
 
 .board-wrapper {
   position: relative;
-  flex: 1 1 65%;
-  min-height: 600px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  flex: 1 1 480px;
+  max-width: 640px;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 12px;
 }
 
 #board-background {
   position: absolute;
-  inset: 4rem;
-  border-radius: 24px;
-  background: rgba(15, 23, 42, 0.8);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
-  background-image: radial-gradient(rgba(148, 163, 184, 0.15) 1px, transparent 0);
-  background-size: 40px 40px;
-}
-
-#board,
-#placement-layer {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  place-items: center;
-}
-
-#board {
-  pointer-events: auto;
-}
-
-#placement-layer {
+  inset: 12px;
+  border: 1px dashed #d1d5db;
   pointer-events: none;
 }
 
-.board-grid {
+#board {
   display: grid;
-  position: relative;
-  transition: grid-template 0.3s ease;
+  gap: 6px;
+  justify-content: center;
+  align-content: center;
 }
 
+.board-tile,
 .empty-cell {
-  width: var(--tile-size);
-  height: var(--tile-size);
-  border-radius: 18px;
-  border: 1px dashed rgba(148, 163, 184, 0.18);
-  background: rgba(148, 163, 184, 0.05);
+  width: 72px;
+  height: 72px;
+  position: relative;
+  background: #e6e6e6;
+  border: 1px solid #bbb;
 }
 
 .board-tile {
-  width: var(--tile-size);
-  height: var(--tile-size);
-  background: var(--tile);
-  border-radius: 18px;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  position: relative;
-  overflow: hidden;
-  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.4);
-  pointer-events: auto;
+  background: #d9edf7;
+  --tx: 0px;
+  --ty: 0px;
+  --angle: 0deg;
+  transform: translate(var(--tx), var(--ty)) rotate(var(--angle));
+  transition: transform 0.5s ease;
 }
 
-.board-tile.animated {
-  transition: transform 0.5s ease;
+.board-tile.rotating {
+  transition: transform 0.35s ease;
+}
+
+.board-tile.shift-highlight {
+  outline: 3px solid #2563eb;
 }
 
 .board-tile .segments {
   position: absolute;
-  inset: 12px;
+  inset: 6px;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: 1fr 1fr 1fr;
-  gap: 4px;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  gap: 2px;
+}
+
+.segment {
+  background: #f8f9fa;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  border: 1px solid transparent;
+}
+
+.segment.soft {
+  background: #c7f9cc;
+}
+
+.segment.neutral {
+  background: #cfe0ff;
+}
+
+.segment.hard {
+  background: #e1c3ff;
+}
+
+.segment.finish {
+  border: 1px solid #3b82f6;
+  font-weight: 600;
 }
 
 .tile-number {
   position: absolute;
-  right: 6px;
-  bottom: 6px;
-  color: var(--tile-number);
-  font-size: 0.65rem;
-  font-weight: 600;
-  background: rgba(15, 23, 42, 0.6);
-  padding: 2px 6px;
-  border-radius: 12px;
+  bottom: 4px;
+  right: 4px;
+  font-size: 0.6rem;
+  color: #666;
 }
-
-.segment {
-  border-radius: 8px;
-  background: rgba(148, 163, 184, 0.12);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.85rem;
-  transition: background 0.2s ease;
-}
-
-.segment.soft { background: rgba(72, 187, 120, 0.2); }
-.segment.neutral { background: rgba(99, 179, 237, 0.2); }
-.segment.hard { background: rgba(183, 148, 244, 0.2); }
-.segment.finish { border: 2px dashed rgba(99, 179, 237, 0.6); font-weight: 600; letter-spacing: 0.02em; }
 
 .token {
   position: absolute;
-  width: var(--token-size);
-  height: var(--token-size);
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
-  border: 4px solid rgba(255, 255, 255, 0.2);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: 700;
-  color: rgba(15, 23, 42, 0.9);
-  transition: transform 0.3s ease, outline 0.3s ease;
-  z-index: 3;
+  font-weight: bold;
+  color: #fff;
   transform: translate(-50%, -50%);
+  transition: transform 0.3s ease, outline 0.3s ease;
+  border: 2px solid rgba(0, 0, 0, 0.2);
 }
 
 .token.active {
-  outline: 4px solid gold;
+  outline: 3px solid gold;
   transform: translate(-50%, -50%) scale(1.1);
 }
 
@@ -189,165 +133,129 @@ button:not(:disabled):hover {
   flex: 0 0 320px;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 12px;
 }
 
 .announcer,
 .controls {
-  background: var(--panel);
-  border-radius: 24px;
-  padding: 1.5rem;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 12px;
 }
 
 .announcer-log {
-  min-height: 220px;
-  max-height: 320px;
+  min-height: 160px;
+  max-height: 260px;
   overflow-y: auto;
-  padding: 1rem;
-  border-radius: 18px;
-  background: rgba(15, 23, 42, 0.7);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  font-size: 0.95rem;
-  line-height: 1.5;
-}
-
-.announcer-log p {
-  margin: 0 0 0.75rem;
+  background: #f9f9f9;
+  padding: 8px;
 }
 
 .dice-display {
   display: flex;
-  gap: 0.75rem;
+  gap: 8px;
   align-items: center;
-  justify-content: center;
-  font-size: 2rem;
-  background: rgba(15, 23, 42, 0.65);
-  border-radius: 20px;
-  padding: 0.5rem 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-}
-
-.dice-display .sum {
-  font-size: 1.25rem;
-  opacity: 0.8;
+  font-size: 1.5rem;
+  margin-top: 8px;
 }
 
 .control-buttons {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 8px;
+}
+
+button {
+  padding: 8px 12px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.menu-overlay,
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.menu-card,
+.modal-card {
+  background: #fff;
+  padding: 24px;
+  border: 1px solid #ccc;
+  text-align: center;
+}
+
+.menu-buttons {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
 }
 
 #placement-layer {
+  position: absolute;
+  inset: 12px;
   pointer-events: none;
 }
 
-.placement-cell {
-  width: var(--tile-size);
-  height: var(--tile-size);
-  border-radius: 18px;
-  border: 2px dashed rgba(99, 179, 237, 0.3);
-  background: rgba(99, 179, 237, 0.12);
+.placement-grid {
+  display: grid;
+  gap: 6px;
+}
+
+.overlay-cell {
+  width: 72px;
+  height: 72px;
+  background: transparent;
+  border: none;
   position: relative;
-  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.placement-cell {
+  width: 72px;
+  height: 72px;
+  border: 2px dashed #9ca3af;
+  background: rgba(147, 197, 253, 0.2);
   pointer-events: auto;
 }
 
 .placement-cell.invalid {
-  opacity: 0.25;
+  opacity: 0.3;
   pointer-events: none;
-}
-
-.placement-cell.highlight {
-  border-color: rgba(72, 187, 120, 0.6);
-  background: rgba(72, 187, 120, 0.18);
 }
 
 .bump-overlay {
   position: absolute;
   inset: 0;
-  display: grid;
   pointer-events: none;
 }
 
-.bump-target {
-  border: 2px dashed rgba(99, 179, 237, 0.8);
-  border-radius: 16px;
-  background: rgba(99, 179, 237, 0.2);
-  pointer-events: auto;
-  transition: transform 0.2s ease;
-}
-
-.bump-target:hover {
-  transform: scale(1.05);
-}
-
-.menu-overlay {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(15, 23, 42, 0.94);
-  z-index: 10;
-}
-
-.menu-card {
-  background: rgba(30, 41, 59, 0.9);
-  padding: 2.5rem 3rem;
-  border-radius: 28px;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
-  text-align: center;
-  max-width: 420px;
-  width: 100%;
-}
-
-.menu-buttons {
+.bump-grid {
   display: grid;
-  gap: 1rem;
-  margin-top: 2rem;
+  gap: 6px;
 }
 
-.modal {
-  position: fixed;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.82);
+.bump-target {
+  background: rgba(99, 179, 237, 0.4);
+  border: 2px dashed #60a5fa;
+  pointer-events: auto;
+  font-size: 0.75rem;
+  padding: 0;
+  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 11;
 }
 
-.modal-card {
-  background: rgba(30, 41, 59, 0.92);
-  border-radius: 24px;
-  padding: 2rem 3rem;
-  text-align: center;
-  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.5);
-}
-
-@media (max-width: 1024px) {
-  body {
-    padding: 1rem;
-  }
-
-  .game {
-    flex-direction: column;
-    align-items: center;
-    padding: 1.5rem 1rem 4rem;
-  }
-
-  .board-wrapper {
-    width: 100%;
-    min-height: 420px;
-  }
-
-  .side-panel {
-    width: 100%;
-    max-width: 520px;
-  }
+.status-inline {
+  margin-top: 8px;
+  font-size: 0.9rem;
 }


### PR DESCRIPTION
## Summary
- add a rotate placement control and adjust shift controls so humans can skip before picking tiles
- filter shiftable tiles/placements to legal options while rendering non-blocking overlays for movement and relocation
- scale the board and overlays as the map grows for better visibility during expanded play

## Testing
- Manual smoke test in browser

------
https://chatgpt.com/codex/tasks/task_e_68db788314f88329992422151dccf7ce